### PR TITLE
Initial h2spec Compliance Fixes

### DIFF
--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2BaseFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2BaseFilter.java
@@ -1022,13 +1022,6 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             throw new Http2StreamException(streamId, ErrorCode.STREAM_CLOSED);
         }
 
-        // @TODO Is there a better spot for this check?
-        // Check stream state to ensure we can send this upstream
-        final IOException error = stream.assertCanAcceptData(fin);
-        if (error != null) {
-            throw error;
-        }
-
         stream.offerInputData(data, fin);
     }
 

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
@@ -762,7 +762,7 @@ public class Http2ServerFilter extends Http2BaseFilter {
 
         // Check the PRI message payload
         final Buffer payload = httpContent.getContent();
-        if (payload.remaining() < PRI_PAYLOAD.length) {
+        if (payload.remaining() - 2 < PRI_PAYLOAD.length) {
             return false;
         }
 


### PR DESCRIPTION
Running the tests from https://github.com/summerwind/h2spec:
- Some tests randomly returned `EOFException`. This was caused by the PRI processing method splitting the payload into two separate payloads, a valid one and an invalid one. The invalid one failed the test. By waiting for 2 extra characters, this doesn't happen.
- `hpack/4.2/1` failed consistently (dynamic table size update should fail after block end). Added a more explicit test for this condition, to correct the result.
- Made the data stream state check (`assertCanAcceptData`) more transparent by calling it inside the `offerInputData` method.