### PR TITLE
Fixed Bug Caused By Old SSLEngine Reference

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
@@ -604,7 +604,6 @@ public class SSLBaseFilter extends BaseFilter {
                                      final Buffer tmpAppBuffer0)
             throws IOException {
 
-        final SSLEngine sslEngine = sslCtx.getSslEngine();
         final Connection connection = ctx.getConnection();
         
         final boolean isLoggingFinest = LOGGER.isLoggable(Level.FINEST);
@@ -614,22 +613,22 @@ public class SSLBaseFilter extends BaseFilter {
         Buffer tmpAppBuffer = tmpAppBuffer0;
         
         try {
-            HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            HandshakeStatus handshakeStatus = sslCtx.getSslEngine().getHandshakeStatus();
 
             _exitWhile:
-            
+
             while (true) {
 
                 if (isLoggingFinest) {
                     LOGGER.log(Level.FINEST, "Loop Engine: {0} handshakeStatus={1}",
-                            new Object[]{sslEngine, sslEngine.getHandshakeStatus()});
+                            new Object[] { sslCtx.getSslEngine(), sslCtx.getSslEngine().getHandshakeStatus() });
                 }
 
                 switch (handshakeStatus) {
                     case NEED_UNWRAP: {
 
                         if (isLoggingFinest) {
-                            LOGGER.log(Level.FINEST, "NEED_UNWRAP Engine: {0}", sslEngine);
+                            LOGGER.log(Level.FINEST, "NEED_UNWRAP Engine: {0}", sslCtx.getSslEngine());
                         }
 
                         if (inputBuffer == null || !inputBuffer.hasRemaining()) {
@@ -661,28 +660,28 @@ public class SSLBaseFilter extends BaseFilter {
                             throw new SSLException("SSL unwrap error: " + status);
                         }
 
-                        handshakeStatus = sslEngine.getHandshakeStatus();
+                        handshakeStatus = sslCtx.getSslEngine().getHandshakeStatus();
                         break;
                     }
 
                     case NEED_WRAP: {
                         if (isLoggingFinest) {
-                            LOGGER.log(Level.FINEST, "NEED_WRAP Engine: {0}", sslEngine);
+                            LOGGER.log(Level.FINEST, "NEED_WRAP Engine: {0}", sslCtx.getSslEngine());
                         }
 
                         tmpNetBuffer = handshakeWrap(
                                 connection, sslCtx, tmpNetBuffer);
-                        handshakeStatus = sslEngine.getHandshakeStatus();
+                        handshakeStatus = sslCtx.getSslEngine().getHandshakeStatus();
 
                         break;
                     }
 
                     case NEED_TASK: {
                         if (isLoggingFinest) {
-                            LOGGER.log(Level.FINEST, "NEED_TASK Engine: {0}", sslEngine);
+                            LOGGER.log(Level.FINEST, "NEED_TASK Engine: {0}", sslCtx.getSslEngine());
                         }
-                        executeDelegatedTask(sslEngine);
-                        handshakeStatus = sslEngine.getHandshakeStatus();
+                        executeDelegatedTask(sslCtx.getSslEngine());
+                        handshakeStatus = sslCtx.getSslEngine().getHandshakeStatus();
                         break;
                     }
 


### PR DESCRIPTION
When under stress, the SSLEngine stored by the SSL context is sometimes replaced. When this happens, the edited method gets stuck in an endless loop with an old SSLEngine that forever needs wrapping (since it doesn't have access to the updated SSLEngine), and therefore won't get garbage collected. This causes high CPU and heap usage until Grizzly is restarted.

This fix simply forces the loop to keep checking that the SSLEngine reference is the correct one.