### PR TITLE
HTTP/2 Memory Leak Fix

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
@@ -1076,9 +1076,9 @@ public class SSLBaseFilter extends BaseFilter {
     } // END InternalProcessingHandler
     
     public interface HandshakeListener {
-        void onStart(Connection connection);
-        void onComplete(Connection connection);
-        void onFailure(Connection connection, Throwable t);
+        void onStart(Connection<?> connection);
+        void onComplete(Connection<?> connection);
+        void onFailure(Connection<?> connection, Throwable t);
     }
     
     protected static class SSLTransportFilterWrapper extends TransportFilter {

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -84,7 +84,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        -XX:+HeapDumpOnOutOfMemoryError -Xbootclasspath/p:${settings.localRepository}/org/glassfish/grizzly/grizzly-npn-bootstrap/1.7/grizzly-npn-bootstrap-1.7.jar
+                        -XX:+HeapDumpOnOutOfMemoryError -Xbootclasspath/p:${settings.localRepository}/org/glassfish/grizzly/grizzly-npn-bootstrap/1.8/grizzly-npn-bootstrap-1.8.jar
                     </argLine>
                 </configuration>
             </plugin>

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
@@ -23,7 +23,9 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.net.ssl.SSLEngine;
+
 import org.glassfish.grizzly.CloseListener;
 import org.glassfish.grizzly.CloseType;
 import org.glassfish.grizzly.Closeable;
@@ -44,7 +46,7 @@ import org.glassfish.grizzly.ssl.SSLUtils;
 public class AlpnSupport {
     private final static Logger LOGGER = Grizzly.logger(AlpnSupport.class);
 
-    private final static Map<SSLEngine, Connection> SSL_TO_CONNECTION_MAP =
+    private final static Map<SSLEngine, Connection<?>> SSL_TO_CONNECTION_MAP =
             new WeakHashMap<>();
     
     private static final AlpnSupport INSTANCE;
@@ -74,14 +76,14 @@ public class AlpnSupport {
         return INSTANCE;
     }
 
-    public static Connection getConnection(final SSLEngine engine) {
+    public static Connection<?> getConnection(final SSLEngine engine) {
         synchronized (SSL_TO_CONNECTION_MAP) {
             return SSL_TO_CONNECTION_MAP.get(engine);
         }
     }
     
     private static void setConnection(final SSLEngine engine,
-            final Connection connection) {
+            final Connection<?> connection) {
         synchronized (SSL_TO_CONNECTION_MAP) {
             SSL_TO_CONNECTION_MAP.put(engine, connection);
         }
@@ -99,7 +101,7 @@ public class AlpnSupport {
             new SSLFilter.HandshakeListener() {
 
         @Override
-        public void onStart(final Connection connection) {
+        public void onStart(final Connection<?> connection) {
             final SSLEngine sslEngine = SSLUtils.getSSLEngine(connection);
             assert sslEngine != null;
             
@@ -161,11 +163,11 @@ public class AlpnSupport {
         }
 
         @Override
-        public void onComplete(final Connection connection) {
+        public void onComplete(final Connection<?> connection) {
         }
 
         @Override
-        public void onFailure(Connection connection, Throwable t) {
+        public void onFailure(Connection<?> connection, Throwable t) {
         }
     };
     
@@ -181,7 +183,7 @@ public class AlpnSupport {
         putServerSideNegotiator(transport, negotiator);
     }
     
-    public void setServerSideNegotiator(final Connection connection,
+    public void setServerSideNegotiator(final Connection<?> connection,
             final AlpnServerNegotiator negotiator) {
         putServerSideNegotiator(connection, negotiator);
     }
@@ -192,7 +194,7 @@ public class AlpnSupport {
         putClientSideNegotiator(transport, negotiator);
     }
 
-    public void setClientSideNegotiator(final Connection connection,
+    public void setClientSideNegotiator(final Connection<?> connection,
             final AlpnClientNegotiator negotiator) {
         putClientSideNegotiator(connection, negotiator);
     }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
@@ -25,10 +25,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLEngine;
 import org.glassfish.grizzly.CloseListener;
+import org.glassfish.grizzly.CloseType;
 import org.glassfish.grizzly.Closeable;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
-import org.glassfish.grizzly.ICloseType;
 import org.glassfish.grizzly.Transport;
 import org.glassfish.grizzly.npn.AlpnClientNegotiator;
 import org.glassfish.grizzly.npn.AlpnServerNegotiator;
@@ -119,10 +119,11 @@ public class AlpnSupport {
                 if (negotiator != null) {
                     // add a CloseListener to ensure we remove the
                     // negotiator associated with this SSLEngine
-                    connection.addCloseListener(new CloseListener() {
+                    connection.addCloseListener(new CloseListener<Closeable, CloseType>() {
                         @Override
-                        public void onClosed(Closeable closeable, ICloseType type) throws IOException {
-                            NegotiationSupport.removeClientNegotiator(sslEngine);
+                        public void onClosed(Closeable closeable, CloseType type) throws IOException {
+                            NegotiationSupport.removeAlpnClientNegotiator(sslEngine);
+                            SSL_TO_CONNECTION_MAP.remove(sslEngine);
                         }
                     });
                     setConnection(sslEngine, connection);
@@ -145,10 +146,11 @@ public class AlpnSupport {
 
                     // add a CloseListener to ensure we remove the
                     // negotiator associated with this SSLEngine
-                    connection.addCloseListener(new CloseListener() {
+                    connection.addCloseListener(new CloseListener<Closeable, CloseType>() {
                         @Override
-                        public void onClosed(Closeable closeable, ICloseType type) throws IOException {
-                            NegotiationSupport.removeServerNegotiator(sslEngine);
+                        public void onClosed(Closeable closeable, CloseType type) throws IOException {
+                            NegotiationSupport.removeAlpnServerNegotiator(sslEngine);
+                            SSL_TO_CONNECTION_MAP.remove(sslEngine);
                         }
                     });
                     setConnection(sslEngine, connection);

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/AlpnSupportTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/AlpnSupportTest.java
@@ -61,9 +61,15 @@ public class AlpnSupportTest extends AbstractHttp2Test {
             }
         }
 
-        // Perform a garbage collection and wait for it to finish
+        // Perform a garbage collection and wait for 10 seconds to see if the engine reference clears
         System.gc();
-        Thread.sleep(500);
+        for (int i = 0; i < 10; i++) {
+            if (AlpnSupport.getConnection(engine) == null) {
+                break;
+            }
+            System.gc();
+            Thread.sleep(1000);
+        }
 
         // Check the connection is gone
         assertNull("The SSLEngine was left hanging in the ALPN map.", AlpnSupport.getConnection(engine));

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/AlpnSupportTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/AlpnSupportTest.java
@@ -1,0 +1,75 @@
+package org.glassfish.grizzly.http2;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLEngine;
+
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder;
+import org.glassfish.grizzly.npn.NegotiationSupport;
+import org.glassfish.grizzly.ssl.SSLUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AlpnSupportTest extends AbstractHttp2Test {
+
+    public static final int PORT = 18894;
+    private HttpServer server;
+    private TCPNIOTransport clientTransport;
+
+    @Before
+    public void init() throws IOException {
+        server = createServer(null, PORT, true);
+        clientTransport = TCPNIOTransportBuilder.newInstance().setProcessor(createClientFilterChain(true)).build();
+
+        server.start();
+        clientTransport.start();
+    }
+
+    @After
+    public void destroy() throws IOException {
+        clientTransport.shutdownNow();
+        server.shutdownNow();
+    }
+
+    /**
+     * Tests that the SSL_TO_CONNECTION_MAP removes entries from it after the
+     * connection closes.
+     */
+    @Test
+    public void sslToConnectionMapClearTest() throws Exception {
+        SSLEngine engine = null;
+
+        Connection<?> connection = null;
+        try {
+            Future<Connection> connectFuture = clientTransport.connect("localhost", PORT);
+            connection = connectFuture.get(10, TimeUnit.SECONDS);
+            assertNotNull("Failed to get connection to server.", connection);
+            engine = SSLUtils.getSSLEngine(connection);
+        } finally {
+            // Close the client connection
+            if (connection != null) {
+                connection.closeSilently();
+            }
+        }
+
+        // Perform a garbage collection and wait for it to finish
+        System.gc();
+        Thread.sleep(500);
+
+        // Check the connection is gone
+        assertNull("The SSLEngine was left hanging in the ALPN map.", AlpnSupport.getConnection(engine));
+        assertNull("The SSLEngine was left hanging in the negotiation support.", NegotiationSupport.getAlpnClientNegotiator(engine));
+        assertNull("The SSLEngine was left hanging in the negotiation support.", NegotiationSupport.getAlpnServerNegotiator(engine));
+        assertNull("The SSLEngine was left hanging in the negotiation support.", NegotiationSupport.getClientSideNegotiator(engine));
+        assertNull("The SSLEngine was left hanging in the negotiation support.", NegotiationSupport.getServerSideNegotiator(engine));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,6 @@
         <findbugs.skip>false</findbugs.skip>
         <findbugs.common>exclude-common.xml</findbugs.common>
         <jdk.compile.version>1.8</jdk.compile.version>
-        <grizzly.alpn.version>1.7</grizzly.alpn.version>
+        <grizzly.alpn.version>1.8</grizzly.alpn.version>
     </properties>
 </project>


### PR DESCRIPTION
Addresses https://github.com/javaee/glassfish/issues/22539.

Error caused by circular reference between the key and value in the `SSL_TO_CONNECTION_MAP`. Fixed by explicitly removing the key when possible, as well as correcting the `NegotiationSupport` method being used to remove the key.

To test, fire off a load of HTTP/2 requests to the server when running, and observe the size of the `SSL_TO_CONNECTION_MAP`. Before the fix, it kept increasing infinitely. After, it stays consistent with the number of current connections.

- The first commit makes the change to the code.
- The second commit refactors the affected classes (removed depracated `ICloseType`).
- The third commit adds a test for the fix, which passes on this branch and fails on the master branch. The test checks each of the touched maps, so check that the reference to the used `SSLEngine` has been totally removed.
- The fourth commit integrates the NPN version 1.8, to keep the test working on JDK versions more recent than 8_161.
- The final commit adds a bit of resilience to the test, to repeatedly make `System.gc()` calls for 10 seconds or until the reference is properly cleared.