### PR TITLE
Removed call to ensureBufferSize that would immediatly be called again

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLConnectionContext.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLConnectionContext.java
@@ -361,7 +361,6 @@ public final class SSLConnectionContext {
         
         if (allocator != null && isOverflow) {
             updateBufferSizes();
-            output = ensureBufferSize(output, netBufferSize, allocator);
             return wrap(input, output, null);
         } else if (isOverflow || status == Status.BUFFER_UNDERFLOW) {
             return new SslResult(output, new SSLException("SSL wrap error: " + status));


### PR DESCRIPTION
Removes call to `ensureBufferSize` when the next line calls `wrap`, the first line of which is `ensureBufferSize`.