### PR TITLE
Update AjpHandlerFilter.java

### DIFF
--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
@@ -256,6 +256,7 @@ public class AjpHandlerFilter extends BaseFilter {
                 encodedBuffer = Buffers.EMPTY_BUFFER;
             }
         }
+        
 
         assert encodedBuffer != null;
         encodedBuffer.trim();

--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
@@ -252,6 +252,9 @@ public class AjpHandlerFilter extends BaseFilter {
                 return AjpMessageUtils.appendContentAndTrim(memoryManager,
                         encodedBuffer, contentBuffer);
             }
+            else if (encodedBuffer == null) {
+                encodedBuffer = Buffers.EMPTY_BUFFER;
+            }
         }
 
         assert encodedBuffer != null;


### PR DESCRIPTION
GRIZZLY0013: Exception during FilterChain execution
java.lang.NullPointerException
        at org.glassfish.grizzly.http.ajp.AjpHandlerFilter.encodeHttpPacket(AjpHandlerFilter.java:258)


Following this steps to solve de problem.
https://stackoverflow.com/questions/49108190/org-glassfish-grizzly-http-ajp-ajphandlerfilter-encodehttppacketajphandlerfilte