### PR TITLE
Memory leak in DefaultFilterChain, resulting in large amounts of HeapBuffer

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/DefaultFilterChain.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/DefaultFilterChain.java
@@ -482,10 +482,17 @@ public final class DefaultFilterChain extends ListFacadeFilterChain {
             final FiltersState filtersState, final int filterIdx) {
 
         if (filtersState != null) {
+            Object message = ctx.getMessage();
+            if (message instanceof Buffer) {
+                Buffer bufferMessage = (Buffer) message;
+                if (!bufferMessage.hasRemaining()) {
+                    return;
+                }
+            }
             ctx.setMessage(filtersState.append(ctx.getOperation(),
-                    filterIdx, ctx.getMessage()));
+                    filterIdx, message));
+            }
         }
-    }
 
     /**
      * Stores the Filter associated remainder. This remainder will be reused next


### PR DESCRIPTION
The memory leak appeared to come from the MemoryManager
See issues #1703, #1781, #1805, #1905