### PR TITLE
ssl: introduce SSLEngineConfigurator#setSSLParameters

### DIFF
--- a/extras/tls-sni/src/main/java/org/glassfish/grizzly/sni/SNIConfig.java
+++ b/extras/tls-sni/src/main/java/org/glassfish/grizzly/sni/SNIConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -97,16 +97,6 @@ public class SNIConfig {
         @Override
         public SSLEngineConfigurator copy() {
             return new NullSSLEngineConfigurator();
-        }
-
-        @Override
-        public SSLEngineConfigurator setProtocolConfigured(boolean isProtocolConfigured) {
-            throw new IllegalStateException("Immutable config");
-        }
-
-        @Override
-        public SSLEngineConfigurator setCipherConfigured(boolean isCipherConfigured) {
-            throw new IllegalStateException("Immutable config");
         }
 
         @Override


### PR DESCRIPTION
SSLParameters is a class introduced in java6 which can take over
SSLEngineConfigurator. As a first step, let allow applications to
use SSLParameters to configure SSLEngineConfigurator.