### PR TITLE
Update required JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 sudo: false
 script: mvn clean verify


### PR DESCRIPTION
Fixes #2062

With JDK updated project at least is compiled: [travis:536198357](https://travis-ci.org/pzygielo/grizzly/builds/536198357).

I don't see build for PRs at https://ci.eclipse.org/grizzly. May I ask then to consider re-enabling* travis for this repo until one on Eclipse' Infrastructed is created, please?

\* *re-enabling* - as I edit existing travis.yaml I suppose it was once enabled or was intended to be.