### PR TITLE
Only fail the build afterwards, allow all non-impacted builds to continue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
-script: mvn clean verify
+script: mvn --fail-at-end clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ dist: trusty
 jdk:
   - oraclejdk8
 sudo: false
-script: mvn --fail-at-end clean verify
+script: mvn --batch-mode --fail-at-end clean verify


### PR DESCRIPTION
I propose such modification of build script to not break build on first failed module (like [in example for current script](https://travis-ci.org/pzygielo/grizzly/builds/536404963#L7288)), but rather to continue with as many modules/tests as possible (like [in example with `-fae` option](https://api.travis-ci.org/v3/job/536402989/log.txt)).