### PR TITLE
Downgrade required JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk9
+  - oraclejdk8
 sudo: false
 script: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
         </maven.compiler.argument>
         <findbugs.skip>false</findbugs.skip>
         <findbugs.common>exclude-common.xml</findbugs.common>
-        <jdk.compile.version>1.9</jdk.compile.version>
+        <jdk.compile.version>1.8</jdk.compile.version>
         <grizzly.alpn.version>1.9</grizzly.alpn.version>
         <release.arguments></release.arguments>
     </properties>


### PR DESCRIPTION
I propose to set JDK version back to 8, to make master great again.

As declared by @smillidge (https://github.com/eclipse-ee4j/grizzly/pull/2052#issue-268851136) and confirmed with independent [travis](https://travis-ci.org/pzygielo/grizzly/builds/536542641) full build (`verify` goal) completes successfully with JDK 8.

On the other hand - e.g. as reported in https://github.com/eclipse-ee4j/grizzly/issues/2056, master is not ready for newer JDKs.

IMO, `jdk.compile.version` was [updated prematurely](https://github.com/eclipse-ee4j/grizzly/commit/6ce406e20a3febd1a52ae0228aa2bcf9724a1b90#diff-600376dffeb79835ede4a0b285078036R505). It could be bumped once tests and perhaps other elements -- as for example 
https://github.com/eclipse-ee4j/grizzly/blob/807bb9ca784f0803e366d8b049ec31c93ec5982d/modules/http2/pom.xml#L88-L90
uses [option `Xbootclasspath/p` removed in JDK 9](https://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html) which sadly causes failure:
> Corrupted STDOUT by directly writing to native stream in forked JVM 1. Stream '-Xbootclasspath/p is no longer a supported option.'

are migrated/fixed and not break master earlier.

If accepted it sort of fixes #2056.