### PR TITLE
Remove bootclasspath/p option 

### DIFF
--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -86,7 +86,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        -XX:+HeapDumpOnOutOfMemoryError -Xbootclasspath/p:${settings.localRepository}/org/glassfish/grizzly/grizzly-npn-bootstrap/1.8/grizzly-npn-bootstrap-1.8.jar
+                        -XX:+HeapDumpOnOutOfMemoryError
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
If `-Xbootclasspath` points to non-existing entry, like in this case, nothing is reported/no warning from `java` is issued. But it does not prevent tests to [complete successfully](https://travis-ci.org/pzygielo/grizzly/builds/536606888). Hence it seems to be unnecessary.

<sup>Fixes #2066</sup>