### PR TITLE
Reenabled Color in Travis Output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ dist: trusty
 jdk:
   - oraclejdk8
 sudo: false
-script: mvn --batch-mode -Dstyle.color=always --fail-at-end clean verify
+script: mvn --fail-at-end clean verify


### PR DESCRIPTION
@MattGill98 Apparently I misunderstood [you](https://github.com/eclipse-ee4j/grizzly/pull/2064#pullrequestreview-273615932).
As no interactive task (like `release`) is performed, I assumed it WAS about colors, to save few bytes in log or to not have color-control/escape codes in raw log.

Also, `style.color` property does not seem to not work with batch mode enabled - compare https://travis-ci.org/eclipse-ee4j/grizzly/builds/570837112#L6459 and https://travis-ci.org/pzygielo/grizzly/builds/570988115#L6712.
