### PR TITLE
Also copy MonitorConfig in KeepAlive to avoid multiple JmxManagementObjects

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/KeepAlive.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/KeepAlive.java
@@ -32,15 +32,7 @@ public final class KeepAlive implements MonitoringAware<KeepAliveProbe> {
     /**
      * Keep alive probes
      */
-    protected final DefaultMonitoringConfig<KeepAliveProbe> monitoringConfig =
-            new DefaultMonitoringConfig<KeepAliveProbe>(KeepAliveProbe.class) {
-
-        @Override
-        public Object createManagementObject() {
-            return createJmxManagementObject();
-        }
-
-    };
+    protected final DefaultMonitoringConfig<KeepAliveProbe> monitoringConfig;
     
     /**
      * The number int seconds a connection may be idle before being timed out.
@@ -53,13 +45,22 @@ public final class KeepAlive implements MonitoringAware<KeepAliveProbe> {
     private int maxRequestsCount = Constants.DEFAULT_MAX_KEEP_ALIVE;
 
     public KeepAlive() {
+        monitoringConfig = new DefaultMonitoringConfig<KeepAliveProbe>(KeepAliveProbe.class) {
+
+            @Override
+            public Object createManagementObject() {
+                return createJmxManagementObject();
+            }
+
+        };
     }
 
     /**
      * The copy constructor.
-     * @param keepAlive
+     * @param keepAlive the {@link KeepAlive} to copy
      */
     public KeepAlive(final KeepAlive keepAlive) {
+        this.monitoringConfig = keepAlive.monitoringConfig;
         this.idleTimeoutInSeconds = keepAlive.idleTimeoutInSeconds;
         this.maxRequestsCount = keepAlive.maxRequestsCount;
     }


### PR DESCRIPTION
KeepAlive does not copy MonitorConfig. This is a Problem because everytime HttpServerFilter copys the Keepalive Object a new JmxManagementObject will be created.

This fixes #2047.

Signed-off-by: david davidscandurra@gmail.com