### PR TITLE
Add support for JDK 11 ALPN

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,6 +13,9 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * 
+ * Contributors:
+ *  Payara Services - Add support for JDK 9 ALPN API
  */
 
 package org.glassfish.grizzly.ssl;
@@ -792,6 +796,14 @@ public class SSLBaseFilter extends BaseFilter {
         }
     }
 
+    protected void notifyHandshakeInit(final Connection<?> connection, final SSLEngine sslEngine) {
+        if (!handshakeListeners.isEmpty()) {
+            for (final HandshakeListener listener : handshakeListeners) {
+                listener.onInit(connection, sslEngine);
+            }
+        }
+    }
+
     protected void notifyHandshakeStart(final Connection connection) {
         if (!handshakeListeners.isEmpty()) {
             for (final HandshakeListener listener : handshakeListeners) {
@@ -909,6 +921,7 @@ public class SSLBaseFilter extends BaseFilter {
 
             if (sslCtx.getSslEngine() == null) {
                 final SSLEngine sslEngine = sslBaseFilter.serverSSLEngineConfigurator.createSSLEngine();
+                sslBaseFilter.notifyHandshakeInit(connection, sslEngine);
                 sslEngine.beginHandshake();
                 sslCtx.configure(sslEngine);
                 sslBaseFilter.notifyHandshakeStart(connection);

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnSupport.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,15 +13,20 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * 
+ * Contributors:
+ *  Payara Services - Add support for JDK 9 ALPN API
  */
 
 package org.glassfish.grizzly.http2;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,8 +41,8 @@ import org.glassfish.grizzly.Transport;
 import org.glassfish.grizzly.npn.AlpnClientNegotiator;
 import org.glassfish.grizzly.npn.AlpnServerNegotiator;
 import org.glassfish.grizzly.npn.NegotiationSupport;
+import org.glassfish.grizzly.ssl.HandshakeListener;
 import org.glassfish.grizzly.ssl.SSLBaseFilter;
-import org.glassfish.grizzly.ssl.SSLFilter;
 import org.glassfish.grizzly.ssl.SSLUtils;
 
 /**
@@ -49,18 +55,28 @@ public class AlpnSupport {
     private final static Map<SSLEngine, Connection<?>> SSL_TO_CONNECTION_MAP = new WeakHashMap<>();
 
     private static final AlpnSupport INSTANCE;
-
+    private static final Method nativeHandshakeMethod;
+    
     static {
-
         boolean isExtensionFound = false;
+        Method setHandshakeAlpnSelector = null;
+
         try {
-            ClassLoader.getSystemClassLoader().loadClass("sun.security.ssl.GrizzlyNPN");
-            isExtensionFound = true;
-        } catch (Throwable e) {
-            LOGGER.log(Level.FINE, "TLS ALPN extension is not found:", e);
+            setHandshakeAlpnSelector = SSLEngine.class.getMethod("setHandshakeApplicationProtocolSelector", BiFunction.class);
+        } catch (Exception e) {
+            try {
+                ClassLoader.getSystemClassLoader().loadClass("sun.security.ssl.GrizzlyNPN");
+                isExtensionFound = true;
+            } catch (Exception e2) {
+                LOGGER.log(Level.FINE, "Native ALPN is not found:", e);
+                LOGGER.log(Level.FINE, "TLS ALPN extension is not found:", e2);
+            }
         }
 
-        INSTANCE = isExtensionFound ? new AlpnSupport() : null;
+        nativeHandshakeMethod = setHandshakeAlpnSelector;
+        INSTANCE = isExtensionFound
+                || nativeHandshakeMethod != null
+                ? new AlpnSupport() : null;
     }
 
     public static boolean isEnabled() {
@@ -93,7 +109,25 @@ public class AlpnSupport {
     private final Map<Object, AlpnClientNegotiator> clientSideNegotiators = new WeakHashMap<>();
     private final ReadWriteLock clientSideLock = new ReentrantReadWriteLock();
 
-    private final SSLFilter.HandshakeListener handshakeListener = new SSLFilter.HandshakeListener() {
+    private final HandshakeListener handshakeListener = 
+            new HandshakeListener() {
+
+        @Override
+        public void onInit(final Connection<?> connection, final SSLEngine sslEngine) {
+            assert sslEngine != null;
+
+            AlpnServerNegotiator negotiator = getServerNegotiator(connection);
+
+            if (negotiator != null && nativeHandshakeMethod != null) {
+                // Code only works for JDK9+
+                // sslEngine.setHandshakeApplicationProtocolSelector(negotiator);
+                try {
+                    nativeHandshakeMethod.invoke(sslEngine, negotiator);
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, "Couldn't execute sslEngine.setHandshakeApplicationProtocolSelector", ex);
+                }
+            }
+        }
 
         @Override
         public void onStart(final Connection<?> connection) {
@@ -101,18 +135,8 @@ public class AlpnSupport {
             assert sslEngine != null;
 
             if (sslEngine.getUseClientMode()) {
-                AlpnClientNegotiator negotiator;
-                clientSideLock.readLock().lock();
-
-                try {
-                    negotiator = clientSideNegotiators.get(connection);
-                    if (negotiator == null) {
-                        negotiator = clientSideNegotiators.get(connection.getTransport());
-                    }
-                } finally {
-                    clientSideLock.readLock().unlock();
-                }
-
+                AlpnClientNegotiator negotiator = getClientNegotiator(connection);
+                
                 if (negotiator != null) {
                     // add a CloseListener to ensure we remove the
                     // negotiator associated with this SSLEngine
@@ -127,18 +151,8 @@ public class AlpnSupport {
                     NegotiationSupport.addNegotiator(sslEngine, negotiator);
                 }
             } else {
-                AlpnServerNegotiator negotiator;
-                serverSideLock.readLock().lock();
-
-                try {
-                    negotiator = serverSideNegotiators.get(connection);
-                    if (negotiator == null) {
-                        negotiator = serverSideNegotiators.get(connection.getTransport());
-                    }
-                } finally {
-                    serverSideLock.readLock().unlock();
-                }
-
+                AlpnServerNegotiator negotiator = getServerNegotiator(connection);
+                
                 if (negotiator != null) {
 
                     // add a CloseListener to ensure we remove the
@@ -207,6 +221,39 @@ public class AlpnSupport {
         } finally {
             clientSideLock.writeLock().unlock();
         }
+    }
+    
+
+    private AlpnClientNegotiator getClientNegotiator(Connection<?> connection) {
+        AlpnClientNegotiator negotiator;
+        clientSideLock.readLock().lock();
+        
+        try {
+            negotiator = clientSideNegotiators.get(connection);
+            if (negotiator == null) {
+                negotiator = clientSideNegotiators.get(connection.getTransport());
+            }
+        } finally {
+            clientSideLock.readLock().unlock();
+        }
+
+        return negotiator;
+    }
+
+    private AlpnServerNegotiator getServerNegotiator(Connection<?> connection) {
+        AlpnServerNegotiator negotiator;
+        serverSideLock.readLock().lock();
+        
+        try {
+            negotiator = serverSideNegotiators.get(connection);
+            if (negotiator == null) {
+                negotiator = serverSideNegotiators.get(connection.getTransport());
+            }
+        } finally {
+            serverSideLock.readLock().unlock();
+        }
+
+        return negotiator;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <cobertura.version>2.4</cobertura.version>
         <gmbal.version>4.0.0</gmbal.version>
         <osgi.version>4.2.0</osgi.version>
-        <grizzly.alpn.version>1.9</grizzly.alpn.version>
+        <grizzly.alpn.version>2.0</grizzly.alpn.version>
         <release.arguments></release.arguments>
     </properties>
 


### PR DESCRIPTION
Created a new phase in the handshake listener to allow registration of the custom ALPN logic. This allows the HTTP/2 filter to work correctly.

Depends on https://github.com/eclipse-ee4j/grizzly-npn/pull/19, and also assumes that there is a new release of the grizzly-npn API (I've assumed 2.0).

Tested on OpenJDK 11.0.1.