### PR TITLE
fix: Fixes #2110, cast getMessage to Object in FilterChainContext#toString

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainContext.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainContext.java
@@ -926,7 +926,7 @@ public class FilterChainContext implements AttributeStorage {
         sb.append("connection=").append(getConnection());
         sb.append(", closeable=").append(getCloseable());
         sb.append(", operation=").append(getOperation());
-        sb.append(", message=").append(String.valueOf(getMessage()));
+        sb.append(", message=").append((Object) getMessage());
         sb.append(", address=").append(getAddress());
         sb.append(']');
 


### PR DESCRIPTION
Fixes #2110, cast getMessage to Object in FilterChainContext#toString to insure no NPE is thrown because of implicit cast to char[].

Not sure this is the way to go because this will ignore spezialized valueOf methods. This could cause a strange output for arrays.