### PR TITLE
Reset ignoreContentModifiers if incoming/outgoing Upgrade does not succeed

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -1346,12 +1346,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         httpHeader.setIgnoreContentModifiers(true);
 
         ctx.notifyUpstream(HttpEvents.createIncomingUpgradeEvent(httpHeader));
+
+        httpHeader.setIgnoreContentModifiers(false);
     }
 
     protected void onOutgoingUpgrade(final FilterChainContext ctx, final HttpHeader httpHeader) {
         httpHeader.setIgnoreContentModifiers(true);
 
         ctx.notifyUpstream(HttpEvents.createOutgoingUpgradeEvent(httpHeader));
+
+        httpHeader.setIgnoreContentModifiers(false);
     }
 
     protected Buffer encodeHttpPacket(final FilterChainContext ctx, final HttpPacket input) {


### PR DESCRIPTION
Fixes #2117 and #1972 
>If a request with a payload and Upgrade header is received but the server has no filter to handle this specific upgrade the connection times out.

> `ReaderWriter#readFromAsString(java.io.Reader)` does block because of the underlying Buffer. Its calls to `InputBuffer#read`[*](https://github.com/eclipse-ee4j/grizzly/blob/a2ce7775658e11fbccbb9acd32e2daf2b0799f45/modules/http/src/main/java/org/glassfish/grizzly/http/io/InputBuffer.java#L280) then `InputBuffer#fill()`[*](https://github.com/eclipse-ee4j/grizzly/blob/a2ce7775658e11fbccbb9acd32e2daf2b0799f45/modules/http/src/main/java/org/glassfish/grizzly/http/io/InputBuffer.java#L1058) blocks since `ignoreContentModifiers` was set `true` in 
`onIncomingUpgrade`[*](https://github.com/eclipse-ee4j/grizzly/blob/a2ce7775658e11fbccbb9acd32e2daf2b0799f45/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java#L1346) and was never reset on the upgrade path.

Reset ignoreContentModifiers after upgrade. This may not be a appropriate fix. 

Unit test for the Upgrade case should be added.