### PR TITLE
Fix #2078: AJP throws NPE when response body is larger than 8192 bytes

### DIFF
--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
@@ -225,6 +225,8 @@ public class AjpHandlerFilter extends BaseFilter {
             final Buffer contentBuffer = httpContentPacket.getContent();
             if (contentBuffer.hasRemaining()) {
                 return AjpMessageUtils.appendContentAndTrim(memoryManager, encodedBuffer, contentBuffer);
+            } else if (encodedBuffer == null) {
+                encodedBuffer = Buffers.EMPTY_BUFFER;
             }
         }
 


### PR DESCRIPTION
Signed-off-by:Javier Llorente <javier@opensuse.org>