### PR TITLE
introduce FileChunk interface to transfer file chunks

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/FileChunk.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/FileChunk.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly;
+
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+import org.glassfish.grizzly.asyncqueue.WritableMessage;
+
+public interface FileChunk extends WritableMessage {
+
+    /**
+     * Transfers the File region backing this <code>FileRegion</code> to the specified {@link WritableByteChannel}.
+     *
+     * @param c the {@link WritableByteChannel}
+     * @return the number of bytes that have been transferred
+     * @throws IOException if an error occurs while processing
+     * @see java.nio.channels.FileChannel#transferTo(long, long, java.nio.channels.WritableByteChannel)
+     */
+    long writeTo(final WritableByteChannel c) throws IOException;
+
+}

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/FileTransfer.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/FileTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
@@ -24,15 +24,13 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 
-import org.glassfish.grizzly.asyncqueue.WritableMessage;
-
 /**
  * A simple class that abstracts {@link FileChannel#transferTo(long, long, java.nio.channels.WritableByteChannel)} for
  * use with Grizzly 2.0 {@link org.glassfish.grizzly.asyncqueue.AsyncQueueWriter}.
  *
  * @since 2.2
  */
-public class FileTransfer implements WritableMessage {
+public class FileTransfer implements FileChunk {
 
     private FileChannel fileChannel;
     private long len;

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOAsyncQueueWriter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOAsyncQueueWriter.java
@@ -30,7 +30,7 @@ import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.CloseReason;
 import org.glassfish.grizzly.CloseType;
 import org.glassfish.grizzly.Connection;
-import org.glassfish.grizzly.FileTransfer;
+import org.glassfish.grizzly.FileChunk;
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.IOEvent;
 import org.glassfish.grizzly.WriteResult;
@@ -102,8 +102,8 @@ public final class TCPNIOAsyncQueueWriter extends AbstractNIOAsyncQueueWriter {
                 ((TCPNIOConnection) connection).terminate0(null, new CloseReason(CloseType.REMOTELY, e));
                 throw e;
             }
-        } else if (message instanceof FileTransfer) {
-            written = ((FileTransfer) message).writeTo((SocketChannel) connection.getChannel());
+        } else if (message instanceof FileChunk) {
+            written = ((FileChunk) message).writeTo((SocketChannel) connection.getChannel());
             ((TCPNIOConnection) connection).onWrite(null, written);
         } else {
             throw new IllegalStateException("Unhandled message type");

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
@@ -41,7 +41,7 @@ import org.glassfish.grizzly.CompletionHandler;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Context;
 import org.glassfish.grizzly.EmptyCompletionHandler;
-import org.glassfish.grizzly.FileTransfer;
+import org.glassfish.grizzly.FileChunk;
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.GrizzlyFuture;
 import org.glassfish.grizzly.IOEvent;
@@ -635,8 +635,8 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                 connection.terminate0(null, new CloseReason(CloseType.REMOTELY, e));
                 throw e;
             }
-        } else if (message instanceof FileTransfer) {
-            written = (int) ((FileTransfer) message).writeTo((SocketChannel) connection.getChannel());
+        } else if (message instanceof FileChunk) {
+            written = (int) ((FileChunk) message).writeTo((SocketChannel) connection.getChannel());
         } else {
             throw new IllegalStateException("Unhandled message type");
         }

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
@@ -38,7 +38,7 @@ import org.glassfish.grizzly.CompletionHandler;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Context;
 import org.glassfish.grizzly.EmptyCompletionHandler;
-import org.glassfish.grizzly.FileTransfer;
+import org.glassfish.grizzly.FileChunk;
 import org.glassfish.grizzly.GracefulShutdownListener;
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.GrizzlyFuture;
@@ -571,8 +571,8 @@ public final class UDPNIOTransport extends NIOTransport implements FilterChainEn
             }
 
             connection.onWrite(buffer, (int) written);
-        } else if (message instanceof FileTransfer) {
-            written = ((FileTransfer) message).writeTo((DatagramChannel) connection.getChannel());
+        } else if (message instanceof FileChunk) {
+            written = ((FileChunk) message).writeTo((DatagramChannel) connection.getChannel());
         } else {
             throw new IllegalStateException("Unhandled message type");
         }


### PR DESCRIPTION
The FileTransfer class is designed to utilize OS zero-copy capability to
write a file into a socket. However it opens and closes the file. This
might be not optimal if we need to send a ching of a file.

The introduced FileChunk interface aims to add more flexibility.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>