### PR TITLE
Removed deprecated usages of getPeerCertificateChain

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -212,7 +212,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8,)</version>
+                                    <version>[11,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.5.4</version>

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupport.java
@@ -18,6 +18,7 @@
 package org.glassfish.grizzly.ssl;
 
 import java.io.IOException;
+import java.security.cert.Certificate;
 
 /**
  * SSLSupport
@@ -51,16 +52,35 @@ public interface SSLSupport {
     String getCipherSuite() throws IOException;
 
     /**
-     * The client certificate chain (if any).
+     * @return The client certificate chain (if any).
+     * @deprecated use {@link #getPeerCertificates()} instead.
      */
-    Object[] getPeerCertificateChain() throws IOException;
+    @Deprecated(forRemoval = true)
+    default Object[] getPeerCertificateChain() throws IOException {
+        return getPeerCertificates();
+    }
 
     /**
-     * The client certificate chain (if any).
-     * 
-     * @param force If <tt>true</tt>, then re-negotiate the connection if necessary.
+     * @return The client certificate chain (if any).
+     * @throws IOException
      */
-    Object[] getPeerCertificateChain(boolean force) throws IOException;
+    Certificate[] getPeerCertificates() throws IOException;
+
+    /**
+     * @param force If <tt>true</tt>, then re-negotiate the connection if necessary.
+     * @return The client certificate chain (if any).
+     * @deprecated use {@link #getPeerCertificates(boolean)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default Object[] getPeerCertificateChain(boolean force) throws IOException {
+        return getPeerCertificates(force);
+    }
+
+    /**
+     * @param force If <tt>true</tt>, then re-negotiate the connection if necessary.
+     * @return The client certificate chain (if any).
+     */
+    Certificate[] getPeerCertificates(boolean force) throws IOException;
 
     /**
      * Get the keysize.

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Request.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Request.java
@@ -1779,7 +1779,7 @@ public class Request {
     public Principal getUserPrincipal() {
         if (userPrincipal == null) {
             if (getRequest().isSecure()) {
-                X509Certificate certs[] = (X509Certificate[]) getAttribute(Globals.CERTIFICATES_ATTR);
+                X509Certificate[] certs = (X509Certificate[]) getAttribute(Globals.CERTIFICATES_ATTR);
                 if (FORCE_CLIENT_AUTH_ON_GET_USER_PRINCIPAL && (certs == null || certs.length < 1)) {
                     // Force SSL re-handshake and request client auth
                     certs = (X509Certificate[]) getAttribute(Globals.SSL_CERTIFICATE_ATTR);


### PR DESCRIPTION
A message for the kind reviewer: if you think that it would be good to simply remove those methods now marked as deprecated, I can do that. The  `SSLSession.getPeerCertificateChain` used by the old implementation is not existing in JDK17 any more.

In regard to backward compatibility - calling deprecated methods should be still possible, but implementing the interface means implementing the new version.

Locally all tests passed on JDK11 and JDK17.