### PR TITLE
Fixed NPE in toString

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainContext.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -254,7 +255,7 @@ public class FilterChainContext implements AttributeStorage {
 
     /**
      * Get the current processing task state.
-     * 
+     *
      * @return the current processing task state.
      */
     public State state() {
@@ -433,7 +434,7 @@ public class FilterChainContext implements AttributeStorage {
 
     /**
      * Get the general Grizzly {@link Context} this filter context wraps.
-     * 
+     *
      * @return the general Grizzly {@link Context} this filter context wraps.
      */
     public final Context getInternalContext() {
@@ -926,7 +927,8 @@ public class FilterChainContext implements AttributeStorage {
         sb.append("connection=").append(getConnection());
         sb.append(", closeable=").append(getCloseable());
         sb.append(", operation=").append(getOperation());
-        sb.append(", message=").append(String.valueOf(getMessage()));
+        // message can be null, then valueOf(char[]) would be executed -> NPE
+        sb.append(", message=").append(String.valueOf(Object.class.cast(getMessage())));
         sb.append(", address=").append(getAddress());
         sb.append(']');
 
@@ -950,7 +952,6 @@ public class FilterChainContext implements AttributeStorage {
         }
     }
 
-    @SuppressWarnings("deprecation")
     public static final class TransportContext {
         private boolean isBlocking;
         CompletionHandler completionHandler;

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/filterchain/FilterChainContextTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/filterchain/FilterChainContextTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.filterchain;
+
+import java.nio.channels.ServerSocketChannel;
+
+import org.glassfish.grizzly.Buffer;
+import org.glassfish.grizzly.filterchain.FilterChainContext.Operation;
+import org.glassfish.grizzly.memory.Buffers;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.glassfish.grizzly.nio.transport.TCPNIOConnection;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author David Matejcek
+ */
+public class FilterChainContextTest {
+
+    @Test
+    public void testToString_null() throws Exception {
+        assertEquals("FilterChainContext [connection=null, closeable=null, operation=NONE, message=null, address=null]",
+            new FilterChainContext().toString());
+    }
+
+    @Test
+    public void testToString_usual() throws Exception {
+        try (ServerSocketChannel channel = ServerSocketChannel.open()) {
+            final TCPNIOConnection connection = new TCPNIOConnection(new TCPNIOTransport(), channel);
+            final FilterChainContext context = FilterChainContext.create(connection);
+            final Buffer buffer = Buffers.wrap(MemoryManager.DEFAULT_MEMORY_MANAGER, "Ororok orebuh");
+            context.setAddress("localhost");
+            context.setMessage(buffer);
+            context.setOperation(Operation.CONNECT);
+            assertEquals("FilterChainContext ["
+                + "connection=TCPNIOConnection{localSocketAddress=null, peerSocketAddress=null}, "
+                + "closeable=TCPNIOConnection{localSocketAddress=null, peerSocketAddress=null}, "
+                + "operation=CONNECT, "
+                + "message=" + buffer + ", " // contains hashcode
+                + "address=localhost"
+                + "]",
+                context.toString());
+        }
+    }
+}


### PR DESCRIPTION
- getMessage can return also null char[] array; String.valueOf(char[]) doesn't expect that.

Signed-off-by: David Matějček <dmatej@seznam.cz>