### PR TITLE
Fixed default httpOnly value - should be true

### DIFF
--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/SessionCookieConfig.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/SessionCookieConfig.java
@@ -30,7 +30,7 @@ import org.glassfish.grizzly.http.server.Constants;
 public class SessionCookieConfig implements jakarta.servlet.SessionCookieConfig {
 
     private static final int DEFAULT_MAX_AGE = -1;
-    private static final boolean DEFAULT_HTTP_ONLY = false;
+    private static final boolean DEFAULT_HTTP_ONLY = true;
     private static final boolean DEFAULT_SECURE = false;
     private static final String DEFAULT_NAME = "JSESSIONID";
 


### PR DESCRIPTION
- I made a mistake in a461b6e7a13749
- see https://github.com/eclipse-ee4j/grizzly/pull/2156#discussion_r891970471