### PR TITLE
Replace deprecated SSLSession.getPeerCertificateChain with SSLSession.getPeerCertificates

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
@@ -113,7 +113,6 @@ public class SSLSupportImpl implements SSLSupport {
             return null;
         }
 
-        // Convert JSSE's certificate format to the ones we need
         Certificate[] jsseCerts = null;
         try {
             jsseCerts = session.getPeerCertificates();

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
@@ -18,14 +18,11 @@
 package org.glassfish.grizzly.ssl;
 
 import org.glassfish.grizzly.Connection;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.security.cert.CertificateFactory;
-import java.util.logging.Level;
+import java.security.cert.Certificate;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import org.glassfish.grizzly.Grizzly;
 
 /**
@@ -86,40 +83,22 @@ public class SSLSupportImpl implements SSLSupport {
 
     protected java.security.cert.X509Certificate[] getX509Certificates(
             SSLSession session) throws IOException {
-        X509Certificate jsseCerts[] = null;
+        java.security.cert.X509Certificate[] jsseCerts = null;
         try {
-            jsseCerts = session.getPeerCertificateChain();
+            jsseCerts = (java.security.cert.X509Certificate[])session.getPeerCertificates();
         } catch (Throwable ex) {
             // Get rid of the warning in the logs when no Client-Cert is
             // available
         }
 
         if (jsseCerts == null) {
-            jsseCerts = new X509Certificate[0];
-        }
-        java.security.cert.X509Certificate[] x509Certs =
-                new java.security.cert.X509Certificate[jsseCerts.length];
-        for (int i = 0; i < x509Certs.length; i++) {
-            try {
-                byte buffer[] = jsseCerts[i].getEncoded();
-                CertificateFactory cf =
-                        CertificateFactory.getInstance("X.509");
-                ByteArrayInputStream stream =
-                        new ByteArrayInputStream(buffer);
-                x509Certs[i] = (java.security.cert.X509Certificate) cf.generateCertificate(stream);
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.log(Level.FINE, "Cert #" + i + " = " + x509Certs[i]);
-                }
-            } catch (Exception ex) {
-                logger.log(Level.INFO, "Error translating " + jsseCerts[i], ex);
-                return null;
-            }
+            jsseCerts = new java.security.cert.X509Certificate[0];
         }
 
-        if (x509Certs.length < 1) {
+        if (jsseCerts.length < 1) {
             return null;
         }
-        return x509Certs;
+        return jsseCerts;
     }
 
     @Override
@@ -134,14 +113,14 @@ public class SSLSupportImpl implements SSLSupport {
         }
 
         // Convert JSSE's certificate format to the ones we need
-        X509Certificate[] jsseCerts = null;
+        Certificate[] jsseCerts = null;
         try {
-            jsseCerts = session.getPeerCertificateChain();
+            jsseCerts = session.getPeerCertificates();
         } catch (Exception bex) {
             // ignore.
         }
         if (jsseCerts == null) {
-            jsseCerts = new X509Certificate[0];
+            jsseCerts = new Certificate[0];
         }
         if (jsseCerts.length <= 0 && force) {
             session.invalidate();

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLSupportImpl.java
@@ -20,6 +20,7 @@ package org.glassfish.grizzly.ssl;
 import org.glassfish.grizzly.Connection;
 import java.io.IOException;
 import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
@@ -81,18 +82,18 @@ public class SSLSupportImpl implements SSLSupport {
         return getPeerCertificateChain(false);
     }
 
-    protected java.security.cert.X509Certificate[] getX509Certificates(
+    protected X509Certificate[] getX509Certificates(
             SSLSession session) throws IOException {
-        java.security.cert.X509Certificate[] jsseCerts = null;
+        X509Certificate[] jsseCerts = null;
         try {
-            jsseCerts = (java.security.cert.X509Certificate[])session.getPeerCertificates();
+            jsseCerts = (X509Certificate[])session.getPeerCertificates();
         } catch (Throwable ex) {
             // Get rid of the warning in the logs when no Client-Cert is
             // available
         }
 
         if (jsseCerts == null) {
-            jsseCerts = new java.security.cert.X509Certificate[0];
+            jsseCerts = new X509Certificate[0];
         }
 
         if (jsseCerts.length < 1) {


### PR DESCRIPTION
Efforts are underway in the OpenJDK project to remove the long deprecated-for-removal classes in the package `javax.security.cert`. These classes were introduced for backwards compatibility concerns with the unbundled JSSE release for JDK 1.2/1.3, but their use have been discouraged since they were introduced.

It would be good to update Grizzly 2.4.x to not depend on / use these archaic APIs.

See https://bugs.openjdk.org/browse/JDK-8227024 and the corresponding CSR https://bugs.openjdk.org/browse/JDK-8227395

The `SSLSupportImplClass` currently uses `getPeerCertificateChain`, then converts the results to `java.security.cert.X509Certificate`. This seems a bit strange, since the methods could just call `getPeerCertificates` directly, which returns `java.security.cert.X509Certificate[]`.

Merging this PR would allow Grizzly 2.4.x to be used on a future JDK where the deprecated for-removal APIs in `javax.security.cert` are removed.