### PR TITLE
src: remove unintended deprecation annotation

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/AttributeBuilder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/AttributeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,6 @@ public interface AttributeBuilder {
      *
      * @return Attribute<T>
      */
-    @Deprecated
     <T> Attribute<T> createAttribute(String name, Supplier<T> initializer);
 
     /**


### PR DESCRIPTION
The commit cb5fdde0 have dropped NullaryFunction in favor or java.util.Supplier, however, the deprecation annotation was not removed.

fixes: #2196