### PR TITLE
Issue #2212 Enhances validation of HTTP header names

### DIFF
--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -105,7 +105,7 @@ public class BasicCometTest extends TestCase {
         s.setSoLinger(false, 0);
         s.setSoTimeout(500);
         OutputStream os = s.getOutputStream();
-        String a = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\n\n";
+        String a = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\r\n\n";
         System.out.println("     " + a);
         os.write(a.getBytes());
         os.flush();
@@ -167,10 +167,10 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\r\n\n";
+        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\r\n\n";
 
-        String lastCometRequest = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\nConnection: close\n\n";
+        String lastCometRequest = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\r\nConnection: close\r\n\n";
 
         String pipelinedRequest1 = cometRequest + staticRequest + cometRequest;
         String pipelinedRequest2 = cometRequest + staticRequest + lastCometRequest;
@@ -256,8 +256,8 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\r\n\n";
+        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\r\n\n";
 
         try {
             os.write(cometRequest.getBytes());

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -113,9 +113,9 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      */
     private boolean removeHandledContentEncodingHeaders = false;
     
-    private static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
+    public static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
     
-    private static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
+    public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
     
     private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
     

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -22,14 +22,11 @@ import static org.glassfish.grizzly.http.util.HttpCodecUtils.skipSpaces;
 import static org.glassfish.grizzly.utils.Charsets.ASCII_CHARSET;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import java.util.regex.Pattern;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -120,8 +117,6 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
     private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
     
     private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
-    
-    private static final String REGEX_RFC_9110_INVALID_CHARACTERS = "(\\\\n)|(\\\\0)|(\\\\r)|(\\\\x00)|(\\\\x0A)|(\\\\x0D)";
 
     /**
      * File cache probes
@@ -830,6 +825,20 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         while (offset < limit) {
             final byte b = input[offset];
             if (b == Constants.CR) {
+                if (isStrictHeaderValueValidationSet) {
+                    if (offset + 1 < limit) {
+                        final byte b2 = input[offset + 1];
+                        if (b2 == Constants.LF) {
+                            // Continue for next parsing without the validation
+                            offset++;
+                            continue;
+                        }
+                    } else {
+                        // not enough data
+                        parsingState.offset = offset - arrayOffs;
+                        return -1;
+                    }
+                }
             } else if (b == Constants.LF) {
                 // Check if it's not multi line header
                 if (offset + 1 < limit) {
@@ -842,10 +851,6 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBytes(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
-                        if (isStrictHeaderValueValidationSet) {
-                            //make validation with regex mode
-                            validateRFC9110Characters(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
-                        }
                         return 0;
                     }
                 }
@@ -866,35 +871,15 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
-            
+
+            if (isStrictHeaderValueValidationSet && !CookieHeaderParser.isText(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+            }
             offset++;
         }
         parsingState.offset = offset - arrayOffs;
         return -1;
-    }
-
-    private static void validateRFC9110Characters(final byte[] headerValueContent, int start, int end) {
-        if (headerValueContent != null) {
-            if (isInvalidCharacterAvailable(start, end, headerValueContent)) {
-                throw new IllegalStateException(
-                        "An invalid character NUL, LF or CR found in the header value: " + headerValueContent.toString());
-            }
-        }
-    }
-
-    /**
-     * This method evaluates the String from the bytes that contains Header Value and validates if contains literal value
-     * of \n, \r or \0 , in case any of those characters are available return true
-     * @param start index of the starting point to extract characters from the byte array
-     * @param end index of the end point to extract characters from the byte array
-     * @param bytesFromByteChunk represents the bytes from the request message to be processed
-     * @return Boolean true if any of those characters are available
-     */
-    private static boolean isInvalidCharacterAvailable(int start, int end, byte[] bytesFromByteChunk) {
-        byte[] bytesFromHeaderValue = Arrays.copyOfRange(bytesFromByteChunk, start, end);
-        String uft8String = new String(bytesFromHeaderValue, StandardCharsets.UTF_8);
-        Pattern pattern = Pattern.compile(REGEX_RFC_9110_INVALID_CHARACTERS);
-        return pattern.matcher(uft8String).find();
     }
 
     private static void finalizeKnownHeaderNames(final HttpHeader httpHeader, final HeaderParsingState parsingState, final byte[] input, final int start,
@@ -1095,7 +1080,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     b -= Constants.LC_OFFSET;
                 }
                 input.put(offset, b);
-            } else if (b == Constants.CR) {
+            } else if (isStrictHeaderNameValidationSet && b == Constants.CR) {
                 parsingState.offset = offset;
                 final int eol = checkEOL(parsingState, input);
                 if (eol == 0) { // EOL
@@ -1107,7 +1092,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
             }
 
-            if (!CookieHeaderParser.isToken(b)) {
+            if (isStrictHeaderNameValidationSet && !CookieHeaderParser.isToken(b)) {
                 throw new IllegalStateException(
                         "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
@@ -1129,6 +1114,20 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         while (offset < limit) {
             final byte b = input.get(offset);
             if (b == Constants.CR) {
+                if (isStrictHeaderValueValidationSet) {
+                    if (offset + 1 < limit) {
+                        final byte b2 = input.get(offset + 1);
+                        if (b2 == Constants.LF) {
+                            // Continue for next parsing without the validation
+                            offset++;
+                            continue;
+                        }
+                    } else {
+                        // not enough data
+                        parsingState.offset = offset;
+                        return -1;
+                    }
+                }
             } else if (b == Constants.LF) {
                 // Check if it's not multi line header
                 if (offset + 1 < limit) {
@@ -1162,6 +1161,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
 
+            if (isStrictHeaderValueValidationSet && !CookieHeaderParser.isText(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+            }
             offset++;
         }
         parsingState.offset = offset;

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -22,11 +22,14 @@ import static org.glassfish.grizzly.http.util.HttpCodecUtils.skipSpaces;
 import static org.glassfish.grizzly.utils.Charsets.ASCII_CHARSET;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import java.util.regex.Pattern;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -109,6 +112,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      * @see #setRemoveHandledContentEncodingHeaders
      */
     private boolean removeHandledContentEncodingHeaders = false;
+    
+    private static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
+    
+    private static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
+    
+    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
+    
+    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
+    
+    private static final String REGEX_RFC_9110_INVALID_CHARACTERS = "(\\\\n)|(\\\\0)|(\\\\r)|(\\\\x00)|(\\\\x0A)|(\\\\x0D)";
 
     /**
      * File cache probes
@@ -782,7 +795,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     b -= Constants.LC_OFFSET;
                 }
                 input[offset] = b;
-            } else if (b == Constants.CR) {
+            } else if (isStrictHeaderNameValidationSet && b == Constants.CR) {
                 parsingState.offset = offset - arrayOffs;
                 final int eol = checkEOL(parsingState, input, end);
                 if (eol == 0) { // EOL
@@ -794,7 +807,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
             }
 
-            if (!CookieHeaderParser.isToken(b)) {
+            if (isStrictHeaderNameValidationSet && !CookieHeaderParser.isToken(b)) {
                 throw new IllegalStateException(
                         "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
@@ -829,6 +842,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBytes(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
+                        if (isStrictHeaderValueValidationSet) {
+                            //make validation with regex mode
+                            validateRFC9110Characters(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
+                        }
                         return 0;
                     }
                 }
@@ -849,11 +866,35 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
-
+            
             offset++;
         }
         parsingState.offset = offset - arrayOffs;
         return -1;
+    }
+
+    private static void validateRFC9110Characters(final byte[] headerValueContent, int start, int end) {
+        if (headerValueContent != null) {
+            if (isInvalidCharacterAvailable(start, end, headerValueContent)) {
+                throw new IllegalStateException(
+                        "An invalid character NUL, LF or CR found in the header value: " + headerValueContent.toString());
+            }
+        }
+    }
+
+    /**
+     * This method evaluates the String from the bytes that contains Header Value and validates if contains literal value
+     * of \n, \r or \0 , in case any of those characters are available return true
+     * @param start index of the starting point to extract characters from the byte array
+     * @param end index of the end point to extract characters from the byte array
+     * @param bytesFromByteChunk represents the bytes from the request message to be processed
+     * @return Boolean true if any of those characters are available
+     */
+    private static boolean isInvalidCharacterAvailable(int start, int end, byte[] bytesFromByteChunk) {
+        byte[] bytesFromHeaderValue = Arrays.copyOfRange(bytesFromByteChunk, start, end);
+        String uft8String = new String(bytesFromHeaderValue, StandardCharsets.UTF_8);
+        Pattern pattern = Pattern.compile(REGEX_RFC_9110_INVALID_CHARACTERS);
+        return pattern.matcher(uft8String).find();
     }
 
     private static void finalizeKnownHeaderNames(final HttpHeader httpHeader, final HeaderParsingState parsingState, final byte[] input, final int start,

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -240,6 +240,10 @@ public class CookieHeaderParser {
     }
 
     public static boolean isToken(int c) {
+        if (c < 0 || c >= ARRAY_SIZE) {
+            // out of bounds
+            return false;
+        }
         // Fast for correct values, slower for incorrect ones
         try {
             return IS_TOKEN[c];
@@ -249,6 +253,10 @@ public class CookieHeaderParser {
     }
 
     public static boolean isText(int c) {
+        if (c < 0 || c >= 256) {
+            // out of bounds
+            return false;
+        }
         // Fast for correct values, slower for incorrect ones
         try {
             return isText[c];

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -248,6 +248,15 @@ public class CookieHeaderParser {
         }
     }
 
+    public static boolean isText(int c) {
+        // Fast for correct values, slower for incorrect ones
+        try {
+            return isText[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+
 
     /**
      * Custom implementation that skips many of the safety checks in

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright 2004, 2022 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -307,13 +307,13 @@ public class ChunkedTransferEncodingTest {
               .append(eol)
               .append("Host: localhost:")
               .append(PORT)
-              .append(eol)
+              .append("\r\n")
               .append("Transfer-encoding: chunked")
-              .append(eol)
-              .append("Content-Type: application/x-www-form-urlencoded").append(eol);
+              .append("\r\n")
+              .append("Content-Type: application/x-www-form-urlencoded").append("\r\n");
 
             if (i == packetsNum - 1) {
-                sb.append("Connection: close").append(eol);
+                sb.append("Connection: close").append("\r\n");
             }
 
             sb.append(eol);
@@ -327,7 +327,7 @@ public class ChunkedTransferEncodingTest {
             for (Entry<String, Pair<String, String>> entry : trailerHeaders.entrySet()) {
                 final String value = entry.getValue().getFirst();
                 if (value != null) {
-                    sb.append(entry.getKey()).append(": ").append(value).append(eol);
+                    sb.append(entry.getKey()).append(": ").append(value).append("\r\n");
                 }
             }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -19,6 +19,7 @@ package org.glassfish.grizzly.http;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,42 +48,83 @@ import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder;
 import org.glassfish.grizzly.utils.ChunkingFilter;
 import org.glassfish.grizzly.utils.Pair;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
 import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_NAME_VALIDATION_RFC_9110;
 import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_VALUE_VALIDATION_RFC_9110;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Testing HTTP request parsing
  *
  * @author Alexey Stashok
  */
-public class HttpRequestParseTest extends TestCase {
+@RunWith(Parameterized.class)
+public class HttpRequestParseTest {
 
     public static final int PORT = 19000;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
-        System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
+    private final boolean isStrictHeaderNameValidationSet;
+    private final boolean isStrictHeaderValueValidationSet;
+    private final String isStrictHeaderNameValidationSetBefore;
+    private final String isStrictHeaderValueValidationSetBefore;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> getMode() {
+        return asList(new Object[][] { { FALSE, FALSE }, { FALSE, TRUE }, { TRUE, FALSE }, { TRUE, TRUE } });
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
-        System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
+    @Before
+    public void before() throws Exception {
+        if (isStrictHeaderNameValidationSet) {
+            System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
+        } else {
+            System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
+        }
+        if (isStrictHeaderValueValidationSet) {
+            System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
+        } else {
+            System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
+        }
     }
 
+    @After
+    public void after() throws Exception {
+        System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110,
+                           isStrictHeaderNameValidationSetBefore != null ? isStrictHeaderNameValidationSetBefore :
+                           String.valueOf(Boolean.FALSE));
+        System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110,
+                           isStrictHeaderValueValidationSetBefore != null ? isStrictHeaderValueValidationSetBefore :
+                           String.valueOf(Boolean.FALSE));
+    }
+
+    public HttpRequestParseTest(boolean isStrictHeaderNameValidationSet, boolean isStrictHeaderValueValidationSet) {
+        this.isStrictHeaderNameValidationSet = isStrictHeaderNameValidationSet;
+        this.isStrictHeaderValueValidationSet = isStrictHeaderValueValidationSet;
+        this.isStrictHeaderNameValidationSetBefore = System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110);
+        this.isStrictHeaderValueValidationSetBefore = System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110);
+    }
+
+    @Test
     public void testCustomMethod() throws Exception {
         doHttpRequestTest("TAKE", "/index.html", "HTTP/1.0", Collections.<String, Pair<String, String>>emptyMap(), "\r\n");
     }
 
+    @Test
     public void testHeaderlessRequestLine() throws Exception {
         doHttpRequestTest("GET", "/index.html", "HTTP/1.0", Collections.<String, Pair<String, String>>emptyMap(), "\r\n");
     }
 
+    @Test
     public void testSimpleHeaders() throws Exception {
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
@@ -90,6 +132,7 @@ public class HttpRequestParseTest extends TestCase {
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 
+    @Test
     public void testSimpleHeadersPreserveCase() throws Exception {
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
@@ -97,7 +140,11 @@ public class HttpRequestParseTest extends TestCase {
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n", true);
     }
 
-    public void testDisallowedHeaders() {
+    @Test
+    public void testDisallowedCharactersForHeaderNames() {
+        if (!isStrictHeaderNameValidationSet) {
+            return;
+        }
         final StringBuilder sb = new StringBuilder("GET / HTTP/1.1\r\n");
         sb.append("Host: localhost\r\n");
         sb.append(new char[]{0x00, 0x01, 0x02, '\t', '\n', '\r', ' ', '\"', '(', ')', '/', ';', '<', '=', '>', '?', '@',
@@ -110,20 +157,24 @@ public class HttpRequestParseTest extends TestCase {
             // expected
         }
         try {
-            doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\nContent -Length: 1234\n\n", 128);
+            doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\r\nContent -Length: 1234\r\n\n", 128);
             fail("Bad HTTP headers exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
         }
         try {
-            doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\nContent-\rLength: 1234\n\n", 128);
+            doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\r\nContent-\rLength: 1234\r\n\n", 128);
             fail("Bad HTTP headers exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
         }
     }
 
+    @Test
     public void testDisallowedCharactersForHeaderContentValues() {
+        if (!isStrictHeaderValueValidationSet) {
+            return;
+        }
         final StringBuilder sb = new StringBuilder("GET / HTTP/1.1\r\n");
         sb.append("Host: localhost\r\n");
         sb.append("Some-Header: some-");
@@ -134,28 +185,22 @@ public class HttpRequestParseTest extends TestCase {
         doTestDecoder(sb.toString(), 128);
 
         try {
-            doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\\rlhost\nContent -Length: 1234\n\n", 128);
+            doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\rlhost\r\nContent-Length: 1234\r\n\n", 128);
             fail("Bad HTTP headers exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
         }
         try {
-            doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\\nlhost\nContent-Length: 1234\n\n", 128);
-            fail("Bad HTTP headers exception had to be thrown");
-        } catch (IllegalStateException e) {
-            // expected
-        }
-        try {
-            doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\\0lhost\nContent-Length: 1234\n\n", 128);
+            doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\nlhost\r\nContent-Length: 1234\r\n\n", 128);
             fail("Bad HTTP headers exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
         }
 
-        final char[] invalidChars = new char[]{0x00, 0x01, 0x02, '\r'};
+        final char[] invalidChars = new char[]{0x00, 0x01, 0x02, '\r', '\n'};
         for (final char ch : invalidChars) {
             try {
-                doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\nSome-Header: some-" + ch + "value\n\n", 128);
+                doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\r\nSome-Header: some-" + ch + "value\r\n\n", 128);
                 fail("Bad HTTP headers exception had to be thrown");
             } catch (IllegalStateException e) {
                 // expected
@@ -163,7 +208,11 @@ public class HttpRequestParseTest extends TestCase {
         }
     }
 
+    @Test
     public void testIgnoredHeaders() throws Exception {
+        if (!isStrictHeaderNameValidationSet) {
+            return;
+        }
         final Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Ignore\r\nContent-length", new Pair<>("2345", "2345"));
@@ -173,7 +222,12 @@ public class HttpRequestParseTest extends TestCase {
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, expectedHeaders, "\r\n");
     }
 
+    @Test
     public void testMultiLineHeaders() throws Exception {
+        if (isStrictHeaderValueValidationSet) {
+            // Multiline headers should not be supported
+            return;
+        }
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<>("first\r\n          second\r\n       third", "first second third"));
@@ -181,7 +235,12 @@ public class HttpRequestParseTest extends TestCase {
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 
+    @Test
     public void testHeadersN() throws Exception {
+        if (isStrictHeaderValueValidationSet) {
+            // Multiline headers should not be supported
+            return;
+        }
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<>("first\r\n          second\n       third", "first second third"));
@@ -189,26 +248,30 @@ public class HttpRequestParseTest extends TestCase {
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\n");
     }
 
+    @Test
     public void testCompleteURI() throws Exception {
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<String, String>(null, "localhost:8180"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
         doHttpRequestTest(new Pair<>("POST", "POST"), new Pair<>("http://localhost:8180/index.html", "/index.html"),
-                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
+    @Test
     public void testCompleteEmptyURI() throws Exception {
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<String, String>(null, "localhost:8180"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
         doHttpRequestTest(new Pair<>("POST", "POST"), new Pair<>("http://localhost:8180", "/"),
-                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
+    @Test
     public void testDecoderOK() {
         doTestDecoder("GET /index.html HTTP/1.0\n\n", 4096);
     }
 
+    @Test
     public void testDecoderOverflowMethod() {
         try {
             doTestDecoder("GET /index.html HTTP/1.0\n\n", 2);
@@ -218,6 +281,7 @@ public class HttpRequestParseTest extends TestCase {
         }
     }
 
+    @Test
     public void testDecoderOverflowURI() {
         try {
             doTestDecoder("GET /index.html HTTP/1.0\n\n", 8);
@@ -227,6 +291,7 @@ public class HttpRequestParseTest extends TestCase {
         }
     }
 
+    @Test
     public void testDecoderOverflowProtocol() {
         try {
             doTestDecoder("GET /index.html HTTP/1.0\n\n", 19);
@@ -236,19 +301,22 @@ public class HttpRequestParseTest extends TestCase {
         }
     }
 
+    @Test
     public void testDecoderOverflowHeader1() {
         try {
-            doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\n\n", 41);
+            doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\r\n\n", 42);
             fail("Overflow exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
         }
     }
 
+    @Test
     public void testDecoderOverflowHeader2() {
-        doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\n\n", 42);
+        doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\r\n\n", 43);
     }
 
+    @Test
     public void testDecoderOverflowHeader3() {
         try {
             doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\r\n\r\n", 43);
@@ -258,12 +326,14 @@ public class HttpRequestParseTest extends TestCase {
         }
     }
 
+    @Test
     public void testDecoderOverflowHeader4() {
         doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\r\n\r\n", 44);
     }
 
+    @Test
     public void testChunkedTransferEncodingCaseInsensitive() {
-        HttpPacket packet = doTestDecoder("POST /index.html HTTP/1.1\nHost: localhost\nTransfer-Encoding: CHUNked\r\n\r\n0\r\n\r\n", 4096);
+        HttpPacket packet = doTestDecoder("POST /index.html HTTP/1.1\nHost: localhost\r\nTransfer-Encoding: CHUNked\r\n\r\n0\r\n\r\n", 4096);
         assertTrue(packet.getHttpHeader().isChunked());
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
+import java.util.HashMap;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.SocketConnectorHandler;

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -677,7 +677,7 @@ public class HttpSemanticsTest extends TestCase {
     public void testExplicitConnectionCloseHeader() throws Throwable {
         final TCPNIOConnection connection = new TCPNIOConnection(TCPNIOTransportBuilder.newInstance().build(), null);
 
-        Buffer requestBuf = Buffers.wrap(connection.getMemoryManager(), "GET /path HTTP/1.1\n" + "Host: localhost:" + PORT + '\n' + '\n');
+        Buffer requestBuf = Buffers.wrap(connection.getMemoryManager(), "GET /path HTTP/1.1\n" + "Host: localhost:" + PORT + "\r\n" + '\n');
 
         FilterChainContext ctx = FilterChainContext.create(connection);
         ctx.setMessage(requestBuf);


### PR DESCRIPTION
This is a PR for Issue #2212.

The patch contains two contents.

1. If the HTTP header name contains `\r\n` and it is an incomplete packet, ignore it and proceed with parsing. At this time, I was wondering whether to allow not only `\r\n` but also single `\n`, so for now, I decided to allow only `\r\n`.
2. Since there is an existing validation utility that validates cookie headers(https://github.com/eclipse-ee4j/grizzly/blob/master/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java), I tried using the existing validation instead of creating a new one.

Overall, I patched it so that there would be no major changes while maintaining the existing logic, and added related test cases.