### PR TITLE
Issue #2215 Fix invalid Origin header sent by client for non-SSL WebSocket connections

### DIFF
--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/HandShake.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/HandShake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,7 +64,7 @@ public abstract class HandShake {
             resourcePath += "?" + url.getQuery();
         }
         serverHostName = url.getHost();
-        secure = "wss://".equals(url.getScheme());
+        secure = "wss".equals(url.getScheme());
         port = url.getPort();
 
         final StringBuilder sb = new StringBuilder(32).append(getScheme()).append("://").append(url.getHost());
@@ -385,6 +385,6 @@ public abstract class HandShake {
     }
 
     private String getScheme() {
-        return isSecure() ? "ws" : "wss";
+        return isSecure() ? "wss" : "ws";
     }
 }

--- a/modules/websockets/src/test/java/org/glassfish/grizzly/websockets/HandShakeTest.java
+++ b/modules/websockets/src/test/java/org/glassfish/grizzly/websockets/HandShakeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.websockets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+
+import org.glassfish.grizzly.websockets.rfc6455.RFC6455HandShake;
+import org.junit.Test;
+
+public class HandShakeTest {
+    private static final Logger LOGGER = Logger.getLogger("HandShakeTest");
+    private static String SSL = "wss://localhost:8443";
+    private static String NON_SSL = "ws://localhost:8080";
+    private static String RESOURCE_PATH = "/websocket";
+
+    @Test
+    public void testOrigin() throws URISyntaxException {
+        // non-ssl
+        HandShake handshake = new RFC6455HandShake(new URI(NON_SSL + RESOURCE_PATH));
+        LOGGER.info("Handshake: isSecure=" + handshake.isSecure() + ", headers: " + handshake.composeHeaders().getHttpHeader());
+        assertEquals(NON_SSL, handshake.getOrigin());
+        assertFalse(handshake.isSecure());
+        assertEquals(NON_SSL + RESOURCE_PATH, handshake.getLocation());
+
+        // ssl
+        handshake = new RFC6455HandShake(new URI(SSL + RESOURCE_PATH));
+        LOGGER.info("Handshake: isSecure=" + handshake.isSecure() + ", headers: " + handshake.composeHeaders().getHttpHeader());
+        assertEquals(SSL, handshake.getOrigin());
+        assertTrue(handshake.isSecure());
+        assertEquals(SSL + RESOURCE_PATH, handshake.getLocation());
+
+
+    }
+}


### PR DESCRIPTION
Fix for incorrect scheme detection within Handshake constructor. See issue #2215.