### PR TITLE
Issue #2226 "Support for SocketOptions.SO_REUSEPORT"

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/NIOTransportBuilder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/NIOTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
@@ -62,6 +62,7 @@ public abstract class NIOTransportBuilder<T extends NIOTransportBuilder> {
     protected int clientSocketSoTimeout = NIOTransport.DEFAULT_CLIENT_SOCKET_SO_TIMEOUT;
     protected int connectionTimeout = NIOTransport.DEFAULT_CONNECTION_TIMEOUT;
     protected boolean reuseAddress = NIOTransport.DEFAULT_REUSE_ADDRESS;
+    protected boolean reusePort = NIOTransport.DEFAULT_REUSE_PORT;
     protected int maxPendingBytesPerConnection = AsyncQueueWriter.AUTO_SIZE;
     protected boolean optimizedForMultiplexing = NIOTransport.DEFAULT_OPTIMIZED_FOR_MULTIPLEXING;
 
@@ -505,6 +506,28 @@ public abstract class NIOTransportBuilder<T extends NIOTransportBuilder> {
     }
 
     /**
+     * Whether both same address and same port may be reused for multiple sockets
+     *
+     * @return SO_REUSEPORT
+     * @see <a href="http://man7.org/linux/man-pages/man7/socket.7.html">Socket man page</a>
+     */
+    public boolean isReusePort() {
+        return reusePort;
+    }
+
+    /**
+     * Sets whether both same address and same port may be reused for multiple sockets
+     *
+     * @param reusePort SO_REUSEPORT
+     * @return this <code>TCPNIOTransportBuilder</code>
+     * @see <a href="http://man7.org/linux/man-pages/man7/socket.7.html">Socket man page</a>
+     */
+    public T setReusePort(boolean reusePort) {
+        this.reusePort = reusePort;
+        return getThis();
+    }
+
+    /**
      * Max asynchronous write queue size in bytes
      * 
      * @return the value is per connection, not transport total.
@@ -572,6 +595,7 @@ public abstract class NIOTransportBuilder<T extends NIOTransportBuilder> {
         transport.setReadBufferSize(readBufferSize);
         transport.setWriteBufferSize(writeBufferSize);
         transport.setReuseAddress(reuseAddress);
+        transport.setReusePort(reusePort);
         transport.setOptimizedForMultiplexing(isOptimizedForMultiplexing());
         transport.getAsyncQueueIO().getWriter().setMaxPendingBytesPerConnection(maxPendingBytesPerConnection);
         return transport;

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
@@ -713,6 +714,14 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(reuseAddress), e);
                 }
+                if (tcpNioTransport.isReusePortAvailable()) {
+                    final boolean reusePort = tcpNioTransport.isReusePort();
+                    try {
+                        socket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
+                    } catch (Throwable t) {
+                        LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                    }
+                }
             } else { // ServerSocketChannel
                 final ServerSocketChannel serverSocketChannel = (ServerSocketChannel) channel;
                 final ServerSocket serverSocket = serverSocketChannel.socket();
@@ -723,6 +732,14 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                     serverSocket.setReuseAddress(tcpNioTransport.isReuseAddress());
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(tcpNioTransport.isReuseAddress()), e);
+                }
+                if (tcpNioTransport.isReusePortAvailable()) {
+                    final boolean reusePort = tcpNioTransport.isReusePort();
+                    try {
+                        serverSocket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
+                    } catch (Throwable t) {
+                        LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                    }
                 }
             }
         }

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
@@ -664,6 +665,14 @@ public final class UDPNIOTransport extends NIOTransport implements FilterChainEn
                 datagramSocket.setReuseAddress(udpNioTransport.isReuseAddress());
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(udpNioTransport.isReuseAddress()), e);
+            }
+            if (udpNioTransport.isReusePortAvailable()) {
+                final boolean reusePort = udpNioTransport.isReusePort();
+                try {
+                    datagramSocket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
+                } catch (Throwable t) {
+                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                }
             }
         }
 

--- a/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
+++ b/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
@@ -24,6 +24,9 @@ warning.grizzly.socket.linger.exception=GRIZZLY0003: Can not set SO_LINGER to {0
 warning.grizzly.socket.tcpnodelay.exception=GRIZZLY0004: Can not set TCP_NODELAY to {0}
 warning.grizzly.socket.keepalive.exception=GRIZZLY0005: Can not set SO_KEEPALIVE to {0}
 warning.grizzly.socket.reuseaddress.exception=GRIZZLY0006: Can not set SO_REUSEADDR to {0}
+warning.grizzly.socket.reuseport.exception=GRIZZLY0035: Can not set SO_REUSEPORT to {0}
+fine.grizzly.socket.reuseport.exception=GRIZZLY0036: Can not set SO_REUSEPORT to {0}
+info.grizzly.socket.reuseport.exception=GRIZZLY0037: SO_REUSEPORT not supported
 warning.grizzly.socket.timeout.exception=GRIZZLY0007: Can not set SO_TIMEOUT to {0}
 
 warning.grizzly.tcpselector-handler.acceptchannel.exception=GRIZZLY0008: Exception accepting channel

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/NIOTransportTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/NIOTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -192,6 +192,39 @@ public class NIOTransportTest {
                 assertTrue(connection != null);
                 connection.closeSilently();
             }
+        } finally {
+            transport.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testReusePortBind() throws Exception {
+        if (!transport.isReusePortAvailable()) {
+            return;
+        }
+        LOGGER.log(Level.INFO, "Running: testReusePortBind ({0})", transport.getName());
+
+        final int portsTest = 10;
+        final int onePort = PORT + 1234;
+
+        Connection connection;
+        transport.setReusePort(true);
+
+        try {
+            for (int i = 0; i < portsTest; i++) {
+                try {
+                    transport.bind("localhost", onePort, 4096);
+                } catch (IOException e) {
+                    fail("Unexpected exception type: " + e);
+                }
+            }
+
+            transport.start();
+
+            Future<Connection> future = transport.connect("localhost", onePort);
+            connection = future.get(10, TimeUnit.SECONDS);
+            assertTrue(connection != null);
+            connection.closeSilently();
         } finally {
             transport.shutdownNow();
         }


### PR DESCRIPTION
Supports SO_REUSEPORT.

SO_REUSEPORT(reusePort) is supported with interfaces very similar to the set of SO_REUSEADDR(reuseAddress). 
The default value of reusePort is false.

Since SO_REUSEPORT is not supported on all platforms, StandardSocketOptions.SO_REUSEPORT is set only in environments where it is possible through a logic check for SO_REUSEPORT support that is executed only once.