### PR TITLE
Addressed null pointer when constructing a string dataframe

### DIFF
--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
@@ -18,7 +18,6 @@ package org.glassfish.grizzly.websockets;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Objects;
 
 import org.glassfish.grizzly.utils.Charsets;
 
@@ -33,7 +32,6 @@ public class DataFrame {
         return o instanceof DataFrame;
     }
 
-    private static final byte[] EMPTY_ARRAY = new byte[0];
     private String payload;
     private byte[] bytes;
     private final FrameType type;

--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
@@ -99,7 +99,7 @@ public class DataFrame {
     @Override
     public String toString() {
         return new StringBuilder("DataFrame").append("{").append("last=").append(last).append(", type=").append(type.getClass().getSimpleName())
-                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(Objects.requireNonNullElse(getBytes(), EMPTY_ARRAY))).append('}').toString();
+                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(getBytes())).append('}').toString();
     }
 
     public boolean isLast() {

--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
@@ -18,6 +18,7 @@ package org.glassfish.grizzly.websockets;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 
 import org.glassfish.grizzly.utils.Charsets;
 
@@ -32,6 +33,7 @@ public class DataFrame {
         return o instanceof DataFrame;
     }
 
+    private static final byte[] EMPTY_ARRAY = new byte[0];
     private String payload;
     private byte[] bytes;
     private final FrameType type;
@@ -97,7 +99,7 @@ public class DataFrame {
     @Override
     public String toString() {
         return new StringBuilder("DataFrame").append("{").append("last=").append(last).append(", type=").append(type.getClass().getSimpleName())
-                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(bytes)).append('}').toString();
+                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(Objects.requireNonNullElse(getBytes(), EMPTY_ARRAY))).append('}').toString();
     }
 
     public boolean isLast() {

--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/DataFrame.java
@@ -97,7 +97,7 @@ public class DataFrame {
     @Override
     public String toString() {
         return new StringBuilder("DataFrame").append("{").append("last=").append(last).append(", type=").append(type.getClass().getSimpleName())
-                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(getBytes())).append('}').toString();
+                .append(", payload='").append(getTextPayload()).append('\'').append(", bytes=").append(Utils.toString(bytes)).append('}').toString();
     }
 
     public boolean isLast() {

--- a/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/Utils.java
+++ b/modules/websockets/src/main/java/org/glassfish/grizzly/websockets/Utils.java
@@ -135,6 +135,11 @@ public final class Utils {
 
     public static long toLong(byte[] bytes, int start, int end) {
         long value = 0;
+
+        if (bytes == null) {
+            return value;
+        }
+
         for (int i = start; i < end; i++) {
             value <<= 8;
             value ^= (long) bytes[i] & 0xFF;
@@ -143,11 +148,20 @@ public final class Utils {
     }
 
     public static List<String> toString(byte[] bytes) {
+        if (bytes == null) {
+            return new ArrayList<>();
+        }
+
         return toString(bytes, 0, bytes.length);
     }
 
     public static List<String> toString(byte[] bytes, int start, int end) {
         List<String> list = new ArrayList<>();
+
+        if (bytes == null) {
+            return list;
+        }
+
         for (int i = start; i < end; i++) {
             list.add(Integer.toHexString(bytes[i] & 0xFF).toUpperCase(Locale.US));
         }

--- a/modules/websockets/src/test/java/org/glassfish/grizzly/websockets/UtilsTest.java
+++ b/modules/websockets/src/test/java/org/glassfish/grizzly/websockets/UtilsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.websockets;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class UtilsTest {
+
+    @Test
+    public void testToLong() {
+        // Basic case
+        {
+            byte[] bytes = new byte[]{1, 2, 3};
+            long value = Utils.toLong(bytes, 0, bytes.length);
+            assertEquals(66051L, value);
+        }
+
+        // Null case
+        {
+            long value = Utils.toLong(null, 0, 1);
+            assertEquals(0L, value);
+        }
+    }
+
+    @Test
+    public void testToString() {
+        // Basic case
+        {
+            byte[] bytes = new byte[]{1, 2};
+            List<String> list = Utils.toString(bytes);
+            assertEquals(2, list.size());
+            assertEquals("1", list.get(0));
+            assertEquals("2", list.get(1));
+        }
+
+        // Null case
+        {
+            List<String> list = Utils.toString(null);
+            assertEquals(0, list.size());
+        }
+    }
+
+    @Test
+    public void testToStringCustom() {
+        // Basic case
+        {
+            byte[] bytes = new byte[]{1, 2};
+            List<String> list = Utils.toString(bytes, 0, bytes.length);
+            assertEquals(2, list.size());
+            assertEquals("1", list.get(0));
+            assertEquals("2", list.get(1));
+        }
+
+        // Null case
+        {
+            List<String> list = Utils.toString(null, 0, 1);
+            assertEquals(0, list.size());
+        }
+    }
+}


### PR DESCRIPTION
There is a risk of throwing a `NullPointerException` when calling `toString()` on the `DataFrame`. This can occur due to the `bytes` instance variable not being set. This fix will ensure that the `toString()` call prints out the correct payload for `bytes` or defaults to a reasonable value. This is a small fix to address the current behavior, but I'm sure there are other approaches to preventing this issue. For example, converting `DataFrame` to an immutable object so all values are set during initialization. 

To reproduce this bug, initialize a `DataFrame` using `DataFrame(FrameType type)` or one of the `String` based construtors. Finally, I ran into this bug after enabling logging.