### PR TITLE
transport: remove reflection-based muticast support discovery

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOConnection.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOConnection.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Despite that commit ecfddb8c9 has removed the Java version check, the reflection-based compatibility code was still in place. Result:

Remove reflection-based muticast discovery in UDPNIOConnection. Modernize some loops.