### PR TITLE
Use Central to get Maven from

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: ${{ matrix.java_version }}
     - name: Install Maven
       run: |
-        curl -o ./apache-maven-3.9.9-bin.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        curl -o ./apache-maven-3.9.9-bin.tar.gz https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
         tar -xf ./apache-maven-3.9.9-bin.tar.gz
     - name: Maven Build
       run: |
@@ -63,7 +63,7 @@ jobs:
         java-version: ${{ matrix.java_version }}
     - name: Install Maven
       run: |
-        curl -o ./apache-maven-3.9.9-bin.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        curl -o ./apache-maven-3.9.9-bin.tar.gz https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
         tar -xf ./apache-maven-3.9.9-bin.tar.gz
     - name: Maven Build
       run: |


### PR DESCRIPTION
Only the latest versions are served by https://dlcdn.apache.org/maven/maven-3/.