### PR TITLE
Contribution to protect against invalid usage of headers

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -588,6 +588,12 @@ public class HttpServerFilter extends HttpCodecFilter {
 
         final MimeHeaders headers = request.getHeaders();
 
+        //here we can add validation to prevent Http Server invalid use of headers
+        if (headers.contains(Header.ContentLength) && headers.contains(Header.TransferEncoding)) {
+            request.getProcessingState().error = true;
+            return;
+        }
+
         DataChunk hostDC = null;
 
         // Check for a full URI (including protocol://host:port/)

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
@@ -349,12 +349,8 @@ public class HttpSemanticsTest extends TestCase {
 
         ExpectedResult result = new ExpectedResult();
         result.setProtocol("HTTP/1.1");
-        result.setStatusCode(200);
+        result.setStatusCode(400);
         result.addHeader("Connection", "close");
-        result.addHeader("!Transfer-Encoding", "chunked");
-        result.addHeader("!Content-Length", "0");
-        result.setStatusMessage("ok");
-        result.appendContent("Hello World");
         doTest(new ClientFilter(request, result), new BaseFilter() {
             @Override
             public NextAction handleRead(FilterChainContext ctx) throws IOException {


### PR DESCRIPTION
This is a fix to prevent issues when managing headers on grizzly. Based
on the [RFC-7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3) on the section 3.3.3 was mention the following:

If a message is received with both a Transfer-Encoding and a
Content-Length header field, the Transfer-Encoding overrides the
Content-Length. Such a message might indicate an attempt to
perform request smuggling (Section 9.5) or response splitting
(Section 9.4) and ought to be handled as an error. A sender MUST
remove the received Content-Length field prior to forwarding such
a message downstream.

The fix will filter the message and will return Bad Request if both headers are
available:

```
printf 'POST /simple/rest/hello/sleep?s=5 HTTP/1.1\r Host: localhost\r Transfer-Encoding: chunked\r Content-Length: 5\r \r 0\r \r GET /simple/rest/hello HTTP/1.1\r Host: localhost\r \r ' | nc localhost 8080`
```

the result from the call will be the Bad Request error:

<img width="980" height="346" alt="image" src="https://github.com/user-attachments/assets/b5f61d84-5bbf-4a2b-b10f-1d24e93c33fb" />
