### PR TITLE
Issue #2228 "Grizzly NPE in DefaultFilterChain, this.serverRequest is…

### DIFF
--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOInputStreamImpl.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOInputStreamImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,7 +33,7 @@ import org.glassfish.grizzly.http.io.NIOInputStream;
  */
 final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
 
-    private InputBuffer inputBuffer;
+    private volatile InputBuffer inputBuffer;
 
     // ------------------------------------------------ Methods from InputStream
 
@@ -41,6 +42,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public int read() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.readByte();
     }
 
@@ -49,6 +53,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public int read(byte[] b) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.read(b, 0, b.length);
     }
 
@@ -57,6 +64,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.read(b, off, len);
     }
 
@@ -65,6 +75,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public long skip(long n) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.skip(n);
     }
 
@@ -73,6 +86,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public int available() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.available();
     }
 
@@ -81,6 +97,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public void close() throws IOException {
+        if (!initialized()) {
+            return;
+        }
         inputBuffer.close();
     }
 
@@ -89,6 +108,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public void mark(int readlimit) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         inputBuffer.mark(readlimit);
     }
 
@@ -97,6 +119,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public void reset() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         inputBuffer.reset();
     }
 
@@ -107,6 +132,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public boolean markSupported() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.markSupported();
     }
 
@@ -117,6 +145,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public void notifyAvailable(ReadHandler handler) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         inputBuffer.notifyAvailable(handler);
     }
 
@@ -125,6 +156,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public void notifyAvailable(ReadHandler handler, int size) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         inputBuffer.notifyAvailable(handler, size);
     }
 
@@ -133,6 +167,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public boolean isFinished() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.isFinished();
     }
 
@@ -141,6 +178,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public int readyData() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.available();
     }
 
@@ -149,6 +189,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public boolean isReady() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.available() > 0;
     }
 
@@ -159,6 +202,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public Buffer getBuffer() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.getBuffer();
     }
 
@@ -167,6 +213,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public Buffer readBuffer() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.readBuffer();
     }
 
@@ -175,6 +224,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
      */
     @Override
     public Buffer readBuffer(final int size) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.readBuffer(size);
     }
     // -------------------------------------------------- Methods from Cacheable
@@ -195,5 +247,9 @@ final class NIOInputStreamImpl extends NIOInputStream implements Cacheable {
 
         this.inputBuffer = inputBuffer;
 
+    }
+
+    private boolean initialized() {
+        return inputBuffer != null;
     }
 }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOOutputStreamImpl.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOOutputStreamImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,7 +33,7 @@ import org.glassfish.grizzly.http.io.OutputBuffer;
  */
 class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
 
-    private OutputBuffer outputBuffer;
+    private volatile OutputBuffer outputBuffer;
 
     // ----------------------------------------------- Methods from OutputStream
 
@@ -41,6 +42,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void write(final int b) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.writeByte(b);
     }
 
@@ -49,6 +53,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void write(final byte[] b) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(b);
     }
 
@@ -57,6 +64,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(b, off, len);
     }
 
@@ -65,6 +75,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void flush() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.flush();
     }
 
@@ -73,6 +86,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void close() throws IOException {
+        if (!initialized()) {
+            return;
+        }
         outputBuffer.close();
     }
 
@@ -86,6 +102,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
     @Deprecated
     @Override
     public boolean canWrite(final int length) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return outputBuffer.canWrite();
     }
 
@@ -94,6 +113,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public boolean canWrite() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return outputBuffer.canWrite();
     }
 
@@ -106,6 +128,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
     @Deprecated
     @Override
     public void notifyCanWrite(final WriteHandler handler, final int length) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         outputBuffer.notifyCanWrite(handler);
     }
 
@@ -114,6 +139,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void notifyCanWrite(final WriteHandler handler) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         outputBuffer.notifyCanWrite(handler);
     }
 
@@ -124,6 +152,9 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
      */
     @Override
     public void write(final Buffer buffer) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.writeBuffer(buffer);
     }
 
@@ -144,4 +175,7 @@ class NIOOutputStreamImpl extends NIOOutputStream implements Cacheable {
 
     }
 
+    private boolean initialized() {
+        return outputBuffer != null;
+    }
 }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOReaderImpl.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOReaderImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,7 +33,7 @@ import org.glassfish.grizzly.http.io.NIOReader;
  */
 final class NIOReaderImpl extends NIOReader implements Cacheable {
 
-    private InputBuffer inputBuffer;
+    private volatile InputBuffer inputBuffer;
 
     // ----------------------------------------------------- Methods from Reader
 
@@ -41,6 +42,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public int read(final CharBuffer target) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.read(target);
     }
 
@@ -49,6 +53,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public int read() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.readChar();
     }
 
@@ -57,6 +64,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public int read(final char[] cbuf) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.read(cbuf, 0, cbuf.length);
     }
 
@@ -65,6 +75,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public long skip(final long n) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.skip(n);
     }
 
@@ -91,6 +104,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public void mark(int readAheadLimit) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         inputBuffer.mark(readAheadLimit);
     }
 
@@ -99,6 +115,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public void reset() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         inputBuffer.reset();
     }
 
@@ -107,6 +126,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public int read(final char[] cbuf, final int off, final int len) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         return inputBuffer.read(cbuf, off, len);
     }
 
@@ -115,6 +137,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public void close() throws IOException {
+        if (!initialized()) {
+            return;
+        }
         inputBuffer.close();
     }
 
@@ -125,6 +150,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public void notifyAvailable(final ReadHandler handler) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         inputBuffer.notifyAvailable(handler);
     }
 
@@ -133,6 +161,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public void notifyAvailable(final ReadHandler handler, final int size) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         inputBuffer.notifyAvailable(handler, size);
     }
 
@@ -141,6 +172,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public boolean isFinished() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.isFinished();
     }
 
@@ -149,6 +183,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
      */
     @Override
     public int readyData() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return inputBuffer.availableChar();
     }
 
@@ -178,5 +215,9 @@ final class NIOReaderImpl extends NIOReader implements Cacheable {
 
         this.inputBuffer = inputBuffer;
 
+    }
+
+    private boolean initialized() {
+        return inputBuffer != null;
     }
 }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOWriterImpl.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NIOWriterImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,7 +32,7 @@ import org.glassfish.grizzly.http.io.OutputBuffer;
  */
 final class NIOWriterImpl extends NIOWriter implements Cacheable {
 
-    private OutputBuffer outputBuffer;
+    private volatile OutputBuffer outputBuffer;
 
     // ----------------------------------------------------- Methods from Writer
 
@@ -40,6 +41,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void write(int c) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.writeChar(c);
     }
 
@@ -48,6 +52,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void write(char[] cbuf) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(cbuf);
     }
 
@@ -56,6 +63,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(cbuf, off, len);
     }
 
@@ -64,6 +74,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void write(String str) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(str);
     }
 
@@ -72,6 +85,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void write(String str, int off, int len) throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.write(str, off, len);
     }
 
@@ -80,6 +96,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void flush() throws IOException {
+        if (!initialized()) {
+            throw new IOException("Not initialized");
+        }
         outputBuffer.flush();
     }
 
@@ -88,6 +107,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void close() throws IOException {
+        if (!initialized()) {
+            return;
+        }
         outputBuffer.close();
     }
 
@@ -104,6 +126,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
     @Deprecated
     @Override
     public boolean canWrite(final int length) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return outputBuffer.canWrite();
     }
 
@@ -115,6 +140,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public boolean canWrite() {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         return outputBuffer.canWrite();
     }
 
@@ -132,6 +160,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
     @Deprecated
     @Override
     public void notifyCanWrite(final WriteHandler handler, final int length) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         outputBuffer.notifyCanWrite(handler);
     }
 
@@ -145,6 +176,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
      */
     @Override
     public void notifyCanWrite(final WriteHandler handler) {
+        if (!initialized()) {
+            throw new IllegalStateException("Not initialized");
+        }
         outputBuffer.notifyCanWrite(handler);
     }
 
@@ -166,5 +200,9 @@ final class NIOWriterImpl extends NIOWriter implements Cacheable {
 
         this.outputBuffer = outputBuffer;
 
+    }
+
+    private boolean initialized() {
+        return outputBuffer != null;
     }
 }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/io/ServerOutputBuffer.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/io/ServerOutputBuffer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,6 +18,7 @@
 package org.glassfish.grizzly.http.server.io;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
 
@@ -24,16 +26,17 @@ import org.glassfish.grizzly.CompletionHandler;
 import org.glassfish.grizzly.WriteResult;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.http.io.OutputBuffer;
+import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
 import org.glassfish.grizzly.localization.LogMessages;
 
 public class ServerOutputBuffer extends OutputBuffer {
 
-    private Response serverResponse;
+    private volatile Response serverResponse;
 
     public void initialize(final Response response, final FilterChainContext ctx) {
-        super.initialize(response.getResponse(), response.isSendFileEnabled(), ctx);
         this.serverResponse = response;
+        super.initialize(response.getResponse(), response.isSendFileEnabled(), ctx);
     }
 
     @Override
@@ -42,21 +45,25 @@ public class ServerOutputBuffer extends OutputBuffer {
         if (!sendfileEnabled) {
             throw new IllegalStateException("sendfile support isn't available.");
         }
+        final Response localServerResponse = serverResponse;
+        if (localServerResponse == null) {
+            throw new IllegalStateException("ServerOutputBuffer is not initialized in a Response");
+        }
 
         // check the suspend status at the time this method was invoked
         // and take action based on this value
-        final boolean suspendedAtStart = serverResponse.isSuspended();
+        final boolean suspendedAtStart = localServerResponse.isSuspended();
         final CompletionHandler<WriteResult> ch;
         if (suspendedAtStart && handler != null) {
             // provided CompletionHandler assumed to manage suspend/resume
             ch = handler;
         } else if (!suspendedAtStart && handler != null) {
             // provided CompletionHandler assumed to not managed suspend/resume
-            ch = suspendAndCreateHandler(handler);
+            ch = suspendAndCreateHandler(handler, localServerResponse);
         } else {
             // create internal CompletionHandler that will take the
             // appropriate action depending on the current suspend status
-            ch = createInternalCompletionHandler(file, suspendedAtStart);
+            ch = createInternalCompletionHandler(file, suspendedAtStart, localServerResponse);
         }
         super.sendfile(file, offset, length, ch);
     }
@@ -69,10 +76,28 @@ public class ServerOutputBuffer extends OutputBuffer {
 
     @Override
     protected Executor getThreadPool() {
-        return serverResponse.getRequest().getRequestExecutor();
+        final Response localServerResponse = serverResponse;
+        if (localServerResponse == null) {
+            return null;
+        }
+        final Request serverRequest = localServerResponse.getRequest();
+        return serverRequest != null ? serverRequest.getRequestExecutor() : null;
     }
 
-    private CompletionHandler<WriteResult> createInternalCompletionHandler(final File file, final boolean suspendedAtStart) {
+    @Override
+    protected void blockAfterWriteIfNeeded() throws IOException {
+        if (!initialized()) {
+            // If serverResponse is null, we are in the process of recycling the ServerOutputBuffer.
+            return;
+        }
+        super.blockAfterWriteIfNeeded();
+    }
+
+    private boolean initialized() {
+        return serverResponse != null;
+    }
+
+    private CompletionHandler<WriteResult> createInternalCompletionHandler(final File file, final boolean suspendedAtStart, final Response serverResponse) {
 
         CompletionHandler<WriteResult> ch;
         if (!suspendedAtStart) {
@@ -111,7 +136,7 @@ public class ServerOutputBuffer extends OutputBuffer {
 
     }
 
-    private CompletionHandler<WriteResult> suspendAndCreateHandler(final CompletionHandler<WriteResult> handler) {
+    private CompletionHandler<WriteResult> suspendAndCreateHandler(final CompletionHandler<WriteResult> handler, final Response serverResponse) {
         serverResponse.suspend();
         return new CompletionHandler<WriteResult>() {
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacketImpl.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacketImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -65,7 +66,8 @@ class HttpResponsePacketImpl extends HttpResponsePacket {
      */
     @Override
     public void recycle() {
-        if (getRequest().isExpectContent()) {
+        final HttpRequestPacket localRequest = getRequest();
+        if (localRequest != null && localRequest.isExpectContent()) {
             return;
         }
         reset();

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -123,7 +124,7 @@ public class OutputBuffer {
     private MemoryManager memoryManager;
     private Connection connection;
 
-    private WriteHandler handler;
+    private volatile WriteHandler handler;
 
     private InternalWriteHandler asyncWriteHandler;
 
@@ -897,7 +898,7 @@ public class OutputBuffer {
         return outputHeader.isChunkingAllowed() || outputHeader.getContentLength() != -1;
     }
 
-    private void blockAfterWriteIfNeeded() throws IOException {
+    protected void blockAfterWriteIfNeeded() throws IOException {
 
         if (IS_BLOCKING || isNonBlockingWriteGuaranteed || isLastWriteNonBlocking) {
             return;


### PR DESCRIPTION
… null" (https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2228)

Issue #2214 "NPE when closing OutputBuffer" (https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2214)

+ Fixed an issue where a new request was unintentionally processed as a suspend request because it was referencing a recycled request.

+ Improvements to the use of recycled InputBuffer and OutputBuffer and concurrent access to them. When a request and response are completed and recycled, the associated ServerInputBuffer and ServerOutputBuffer are also recycled. However, if another thread references the InputBuffer and OutputBuffer, an NPE may occur when using these recycled instances. We consider the possibility of unintended usage after recycling, and the possibility of concurrent calls to recycle and use. I did not modify InputBuffer and OutputBuffer to be completely thread-safe; Improvements have been made only to the areas mentioned in the issues above.

+ Patched an NPE that occurred when calling toString() on a recycled HttpRequestPacket instance (preventing an NPE when obtaining the methodBytes of Method).

+ Patched for TransportFilter's exceptionOccurred() not propagating to filter chain (it seems that there was no apparent intention to prevent propagation).