### PR TITLE
Fixed issue #2241 "Grizzly doesn't properly strip whitespace from header values"

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -18,6 +18,7 @@
 package org.glassfish.grizzly.http;
 
 import static org.glassfish.grizzly.http.util.HttpCodecUtils.checkEOL;
+import static org.glassfish.grizzly.http.util.HttpCodecUtils.isSpaceOrTab;
 import static org.glassfish.grizzly.http.util.HttpCodecUtils.put;
 import static org.glassfish.grizzly.http.util.HttpCodecUtils.skipSpaces;
 import static org.glassfish.grizzly.utils.Charsets.ASCII_CHARSET;
@@ -869,7 +870,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     // Check if it's not multi line header
                     if (offset + 1 < limit) {
                         final byte b2 = input[offset + 1];
-                        if (b2 == Constants.SP || b2 == Constants.HT) {
+                        if (isSpaceOrTab(b2)) {
                             input[arrayOffs + parsingState.checkpoint++] = b2;
                             parsingState.offset = offset + 2 - arrayOffs;
                             return -2;
@@ -884,7 +885,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     parsingState.offset = offset - arrayOffs;
                     return -1;
                 }
-            } else if (b == Constants.SP) {
+            } else if (isSpaceOrTab(b)) {
                 if (hasShift) {
                     input[arrayOffs + parsingState.checkpoint++] = b;
                 } else {
@@ -1160,7 +1161,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     // Check if it's not multi line header
                     if (offset + 1 < limit) {
                         final byte b2 = input.get(offset + 1);
-                        if (b2 == Constants.SP || b2 == Constants.HT) {
+                        if (isSpaceOrTab(b2)) {
                             input.put(parsingState.checkpoint++, b2);
                             parsingState.offset = offset + 2;
                             return -2;
@@ -1175,7 +1176,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     parsingState.offset = offset;
                     return -1;
                 }
-            } else if (b == Constants.SP) {
+            } else if (isSpaceOrTab(b)) {
                 if (hasShift) {
                     input.put(parsingState.checkpoint++, b);
                 } else {

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -150,6 +150,7 @@ public class HttpRequestParseTest {
         headers.put("Trailing-OWS-Header1", new Pair<>("some-value  ", "some-value"));
         headers.put("Trailing-OWS-Header2", new Pair<>("some-value\t\t", "some-value"));
         headers.put("OWS-Header", new Pair<>(" \t \t some-value \t \t ", "some-value"));
+        headers.put("Mixed-OWS-Header", new Pair<>(" \t \t some- \t \t value \t \t ", "some- \t \t value"));
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -138,6 +139,18 @@ public class HttpRequestParseTest {
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
         doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n", true);
+    }
+
+    @Test
+    public void testLeadingOrTrailingWhitespaceFromHeaderContentValues() throws Exception {
+        Map<String, Pair<String, String>> headers = new HashMap<>();
+        headers.put("Host", new Pair<>("localhost", "localhost"));
+        headers.put("Leading-OWS-Header1", new Pair<>("  some-value", "some-value"));
+        headers.put("Leading-OWS-Header2", new Pair<>("\t\tsome-value", "some-value"));
+        headers.put("Trailing-OWS-Header1", new Pair<>("some-value  ", "some-value"));
+        headers.put("Trailing-OWS-Header2", new Pair<>("some-value\t\t", "some-value"));
+        headers.put("OWS-Header", new Pair<>(" \t \t some-value \t \t ", "some-value"));
+        doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 
     @Test


### PR DESCRIPTION
Trailing HTAB should be removed during the header values ​​parsing process.

https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values
```
...
A field value does not include leading or trailing whitespace. 
...
```

https://www.rfc-editor.org/rfc/rfc9110.html#name-whitespace
```
  OWS            = *( SP / HTAB )
                 ; optional whitespace
```