### PR TITLE
Issue #2246 "IndexedAttributeHolder is not thread-safe under certain …

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/DefaultAttributeBuilder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/DefaultAttributeBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@ public class DefaultAttributeBuilder implements AttributeBuilder {
 
     @Override
     public AttributeHolder createSafeAttributeHolder() {
-        return new IndexedAttributeHolder(this);
+        return new IndexedMapAttributeHolder(this);
     }
 
     @Override

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/IndexedAttributeHolder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/IndexedAttributeHolder.java
@@ -58,6 +58,15 @@ public final class IndexedAttributeHolder implements AttributeHolder {
         indexedAttributeAccessor = new IndexedAttributeAccessorImpl();
     }
 
+    public IndexedAttributeHolder(final AttributeBuilder attributeBuilder, final int initialCapacity) {
+        this.attributeBuilder = (DefaultAttributeBuilder) attributeBuilder;
+        final int snapshotSize = Math.max(4, initialCapacity);
+        final int[] i2v = new int[snapshotSize];
+        Arrays.fill(i2v, -1);
+        state = new Snapshot(new Object[snapshotSize], i2v, 0);
+        indexedAttributeAccessor = new IndexedAttributeAccessorImpl();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/IndexedMapAttributeHolder.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/attributes/IndexedMapAttributeHolder.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.attributes;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * An {@link AttributeHolder} implementation, which stores {@link Attribute} values in a {@link ConcurrentMap},
+ * accessing them by {@link Attribute#index()}.
+ * <p>
+ * This implementation is thread-safe.
+ *
+ * @author Bongjae Chang
+ */
+@SuppressWarnings("rawtypes")
+public class IndexedMapAttributeHolder implements AttributeHolder {
+
+    private final ConcurrentMap<Integer, Object> valueMap = new ConcurrentHashMap<>();
+    private final IndexedAttributeAccessor indexedAttributeAccessor = new IndexedAttributeAccessorImpl();
+
+    private final DefaultAttributeBuilder attributeBuilder;
+
+    IndexedMapAttributeHolder(final AttributeBuilder attributeBuilder) {
+        this.attributeBuilder = (DefaultAttributeBuilder) attributeBuilder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getAttribute(final String name) {
+        return getAttribute(name, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getAttribute(final String name, final Supplier initializer) {
+        final Attribute attribute = attributeBuilder.getAttributeByName(name);
+        if (attribute != null) {
+            return indexedAttributeAccessor.getAttribute(attribute.index(), initializer);
+        }
+        return initializer != null ? initializer.get() : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAttribute(final String name, final Object value) {
+        Attribute attribute = attributeBuilder.getAttributeByName(name);
+        if (attribute == null) {
+            attribute = attributeBuilder.createAttribute(name);
+        }
+        indexedAttributeAccessor.setAttribute(attribute.index(), value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object removeAttribute(final String name) {
+        final Attribute attribute = attributeBuilder.getAttributeByName(name);
+        if (attribute != null) {
+            return indexedAttributeAccessor.removeAttribute(attribute.index());
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<String> getAttributeNames() {
+        return valueMap.keySet().stream().map(index -> attributeBuilder.getAttributeByIndex(index).name())
+                       .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void copyFrom(final AttributeHolder srcAttributes) {
+        if (srcAttributes == null) {
+            return;
+        }
+        clear();
+        if (srcAttributes instanceof IndexedMapAttributeHolder imah) {
+            valueMap.putAll(imah.valueMap);
+        } else {
+            srcAttributes.getAttributeNames().forEach(name -> setAttribute(name, srcAttributes.getAttribute(name)));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void copyTo(final AttributeHolder dstAttributes) {
+        if (dstAttributes == null) {
+            return;
+        }
+        if (dstAttributes instanceof IndexedMapAttributeHolder imah) {
+            imah.valueMap.clear();
+            imah.valueMap.putAll(valueMap);
+        } else {
+            dstAttributes.clear();
+            valueMap.forEach(
+                    (index, value) -> dstAttributes.setAttribute(attributeBuilder.getAttributeByIndex(index).name(),
+                                                                 value));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void recycle() {
+        clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        valueMap.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AttributeBuilder getAttributeBuilder() {
+        return attributeBuilder;
+    }
+
+    /**
+     * Returns {@link IndexedAttributeAccessor} for accessing {@link Attribute}s by index.
+     *
+     * @return {@link IndexedAttributeAccessor} for accessing {@link Attribute}s by index.
+     */
+    @Override
+    public IndexedAttributeAccessor getIndexedAttributeAccessor() {
+        return indexedAttributeAccessor;
+    }
+
+    /**
+     * {@link IndexedAttributeAccessor} implementation.
+     */
+    private final class IndexedAttributeAccessorImpl implements IndexedAttributeAccessor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Object getAttribute(final int index) {
+            return getAttribute(index, null);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Object getAttribute(final int index, final Supplier initializer) {
+            return valueMap.computeIfAbsent(index, k -> initializer != null ? initializer.get() : null);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void setAttribute(final int index, final Object value) {
+            if (value != null) {
+                valueMap.put(index, value);
+            } else {
+                valueMap.remove(index);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Object removeAttribute(final int index) {
+            return valueMap.remove(index);
+        }
+    }
+}

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,16 +22,23 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.glassfish.grizzly.attributes.Attribute;
 import org.glassfish.grizzly.attributes.AttributeBuilder;
 import org.glassfish.grizzly.attributes.AttributeHolder;
 import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
+import org.glassfish.grizzly.attributes.IndexedAttributeHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -102,6 +110,8 @@ public class AttributesTest {
         AttributeBuilder builder = new DefaultAttributeBuilder();
         AttributeHolder holder = isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
 
+        assertEquals("default", holder.getAttribute("attribute", () -> "default"));
+
         final Attribute<String> attr = builder.createAttribute("attribute", new Supplier<String>() {
             @Override
             public String get() {
@@ -120,10 +130,141 @@ public class AttributesTest {
         AttributeBuilder builder = new DefaultAttributeBuilder();
         AttributeHolder holder = isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
 
+        assertNull(holder.getAttribute("attribute"));
+
         final Attribute<String> attr = builder.createAttribute("attribute");
 
         assertNull(attr.peek(holder));
-        assertEquals(null, attr.get(holder));
+        assertNull(attr.get(holder));
         assertFalse(attr.isSet(holder));
+    }
+
+    @Test
+    public void testAttributesCopy() {
+        final AttributeBuilder builder = new DefaultAttributeBuilder();
+        final AttributeHolder holder =
+                isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
+
+        final int attrCount = 100;
+
+        final Attribute[] attrs = new Attribute[attrCount];
+        IntStream.range(0, attrCount).forEach(i -> attrs[i] = builder.createAttribute("attribute-" + i));
+
+        Arrays.stream(attrs).forEach(attr -> {
+            final String value = "value-" + attr.toString();
+            attr.set(holder, value);
+            assertEquals(value, attr.get(holder));
+        });
+
+        // copy from the same type of holder
+        final AttributeHolder copiedHolder =
+                isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
+        copiedHolder.copyFrom(holder);
+        isSameAttributeHolder(attrs, holder, copiedHolder);
+
+        // copy to the same type of holder
+        final AttributeHolder copyToHolder =
+                isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
+        holder.copyTo(copyToHolder);
+        isSameAttributeHolder(attrs, holder, copyToHolder);
+
+        // copy to another type of holder
+        final AttributeHolder copyToAnotherHolder =
+                !isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
+        holder.copyTo(copyToAnotherHolder);
+        isSameAttributeHolder(attrs, holder, copyToAnotherHolder);
+
+        // copy from another type of holder
+        final AttributeHolder copiedHolder2 =
+                isSafe ? builder.createSafeAttributeHolder() : builder.createUnsafeAttributeHolder();
+        copiedHolder2.copyFrom(copyToAnotherHolder);
+        isSameAttributeHolder(attrs, copyToAnotherHolder, copiedHolder2);
+    }
+
+    private static void isSameAttributeHolder(final Attribute[] attrs, final AttributeHolder expected,
+                                              final AttributeHolder actual) {
+        assertEquals(expected.getAttributeNames(), actual.getAttributeNames());
+        Arrays.stream(attrs).forEach(attr -> {
+            assertEquals(attr.get(expected), attr.get(actual));
+        });
+    }
+
+    @Test
+    public void testAttributesInMultiThreads() {
+        if (!isSafe) {
+            return;
+        }
+        final AttributeBuilder builder = new DefaultAttributeBuilder();
+        final AttributeHolder holder = builder.createSafeAttributeHolder();
+
+        final int attrCount = 100;
+        final int numberOfTryCountPerThread = 100;
+
+        final Attribute[] attrs = new Attribute[attrCount];
+        IntStream.range(0, attrCount).forEach(i -> attrs[i] = builder.createAttribute("attribute-" + i));
+
+        // Each thread tries to set/get/remove each attribute multiple times.
+        Arrays.stream(attrs).parallel().forEach(attr -> IntStream.range(0, numberOfTryCountPerThread).forEach(i -> {
+            final String value = "value-" + i;
+            attr.set(holder, value);
+            assertEquals(attr.toString(), value, attr.get(holder));
+            assertEquals(attr.toString(), value, attr.remove(holder));
+            assertNull(attr.toString(), attr.get(holder));
+        }));
+    }
+
+    @Test
+    public void testAttributesForPerformance() {
+        if (!isSafe) {
+            return;
+        }
+        final AttributeBuilder builder = new DefaultAttributeBuilder();
+        final AttributeHolder holder = builder.createSafeAttributeHolder();
+        final AttributeHolder holder2 = new IndexedAttributeHolder(builder); // for comparison
+        final AttributeHolder holder3 = builder.createUnsafeAttributeHolder(); // for comparison
+
+        final int attrCount = 100;
+        final int numberOfTryCountPerThread = 200_000;
+        final int repeatCount = 2;
+
+        final Attribute[] attrs = new Attribute[attrCount];
+        IntStream.range(0, attrCount).forEach(i -> attrs[i] = builder.createAttribute("attribute-" + i));
+
+        for (int i = 0; i < repeatCount; i++) {
+            System.out.println("Performance test iteration #" + (i + 1));
+            long timeElapsed = getMeasureTimeInMillis(attrs, holder, numberOfTryCountPerThread);
+            System.out.println("Time elapsed for Attributes test1 with " + attrs.length + " attributes and " +
+                               numberOfTryCountPerThread + " tries per attribute: " + timeElapsed + " ms");
+            timeElapsed = getMeasureTimeInMillis(attrs, holder2, numberOfTryCountPerThread);
+            System.out.println("Time elapsed for Attributes test2 with " + attrs.length + " attributes and " +
+                               numberOfTryCountPerThread + " tries per attribute: " + timeElapsed + " ms");
+            timeElapsed = getMeasureTimeInMillis(attrs, holder3, numberOfTryCountPerThread);
+            System.out.println("Time elapsed for Attributes test3 with " + attrs.length + " attributes and " +
+                               numberOfTryCountPerThread + " tries per attribute: " + timeElapsed + " ms");
+        }
+    }
+
+    private static long getMeasureTimeInMillis(final Attribute[] attrs, final AttributeHolder holder,
+                                               final int numberOfTryCountPerThread) {
+        final Instant start = Instant.now();
+        // Each thread tries to set/get/remove each attribute multiple times.
+        final CompletableFuture[] futures = Arrays.stream(attrs).map(attr -> CompletableFuture.runAsync(
+                () -> IntStream.range(0, numberOfTryCountPerThread).forEach(i -> {
+                    final String value = "value-" + i;
+                    attr.set(holder, value);
+                    Object result = attr.get(holder);
+                    //assertEquals(attr.toString(), value, result);
+                    result = attr.remove(holder);
+                    //assertEquals(attr.toString(), value, result);
+                    result = attr.get(holder);
+                    //assertNull(attr.toString(), result);
+                }))).toArray(CompletableFuture[]::new);
+        try {
+            CompletableFuture.allOf(futures).orTimeout(30, TimeUnit.SECONDS).join();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        final Instant finish = Instant.now();
+        return Duration.between(start, finish).toMillis();
     }
 }


### PR DESCRIPTION
…circumstances" (https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2246)

+ Implementing a new indexed AttributeHolder based on ConcurrentHashMap and migrating its functionality
+ Added test cases for multi-threaded situations.
+ Added tests to compare performance with existing IndexedAttributeHolder and UnsafeAttributeHolder implementations.
+ Added a constructor that allows you to specify the initial size of IndexedAttributeHolder.