### PR TITLE
(Trivial) Disable the test for attribute holder's performance testing

### DIFF
--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
@@ -39,6 +39,7 @@ import org.glassfish.grizzly.attributes.AttributeBuilder;
 import org.glassfish.grizzly.attributes.AttributeHolder;
 import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
 import org.glassfish.grizzly.attributes.IndexedAttributeHolder;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -213,7 +214,8 @@ public class AttributesTest {
         }));
     }
 
-    //@Test
+    @Test
+    @Ignore("Performance test")
     public void testAttributesForPerformance() {
         if (!isSafe) {
             return;

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/AttributesTest.java
@@ -213,7 +213,7 @@ public class AttributesTest {
         }));
     }
 
-    @Test
+    //@Test
     public void testAttributesForPerformance() {
         if (!isSafe) {
             return;
@@ -224,7 +224,7 @@ public class AttributesTest {
         final AttributeHolder holder3 = builder.createUnsafeAttributeHolder(); // for comparison
 
         final int attrCount = 100;
-        final int numberOfTryCountPerThread = 200_000;
+        final int numberOfTryCountPerThread = 20000;
         final int repeatCount = 2;
 
         final Attribute[] attrs = new Attribute[attrCount];


### PR DESCRIPTION
This can sometimes take several tens of seconds depending on the system environment and performance like this:
https://ci.eclipse.org/glassfish/view/Grizzly/job/Grizzly-master_nightly/2791/