### PR TITLE
Replace SimpleDateFormat used with ThreadLocal into java.time packages #2250

### DIFF
--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -74,6 +74,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-reads org.glassfish.grizzly.http=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Request.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -57,16 +57,16 @@ import org.glassfish.grizzly.http.io.NIOInputStream;
 import org.glassfish.grizzly.http.io.NIOReader;
 import org.glassfish.grizzly.http.server.http2.PushBuilder;
 import org.glassfish.grizzly.http.server.io.ServerInputBuffer;
+import org.glassfish.grizzly.http.server.util.DateTimeFormatters;
 import org.glassfish.grizzly.http.server.util.Globals;
 import org.glassfish.grizzly.http.server.util.MappingData;
 import org.glassfish.grizzly.http.server.util.ParameterMap;
 import org.glassfish.grizzly.http.server.util.RequestUtils;
-import org.glassfish.grizzly.http.server.util.SimpleDateFormats;
 import org.glassfish.grizzly.http.server.util.StringParser;
 import org.glassfish.grizzly.http.util.Chunk;
 import org.glassfish.grizzly.http.util.DataChunk;
-import org.glassfish.grizzly.http.util.FastHttpDateFormat;
 import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpDateFormat;
 import org.glassfish.grizzly.http.util.Parameters;
 import org.glassfish.grizzly.localization.LogMessages;
 import org.glassfish.grizzly.utils.Charsets;
@@ -1423,11 +1423,11 @@ public class Request {
             return -1L;
         }
 
-        final SimpleDateFormats formats = SimpleDateFormats.create();
+        final DateTimeFormatters formats = DateTimeFormatters.create();
 
         try {
             // Attempt to convert the date header in a variety of formats
-            long result = FastHttpDateFormat.parseDate(value, formats.getFormats());
+            long result = HttpDateFormat.parseDate(value, formats.getFormats());
             if (result != -1L) {
                 return result;
             }
@@ -1453,11 +1453,11 @@ public class Request {
             return -1L;
         }
 
-        final SimpleDateFormats formats = SimpleDateFormats.create();
+        final DateTimeFormatters formats = DateTimeFormatters.create();
 
         try {
             // Attempt to convert the date header in a variety of formats
-            long result = FastHttpDateFormat.parseDate(value, formats.getFormats());
+            long result = HttpDateFormat.parseDate(value, formats.getFormats());
             if (result != -1L) {
                 return result;
             }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -26,12 +26,12 @@ import java.io.OutputStream;
 import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -58,9 +58,9 @@ import org.glassfish.grizzly.http.server.util.HtmlHelper;
 import org.glassfish.grizzly.http.util.CharChunk;
 import org.glassfish.grizzly.http.util.ContentType;
 import org.glassfish.grizzly.http.util.CookieSerializerUtils;
-import org.glassfish.grizzly.http.util.FastHttpDateFormat;
 import org.glassfish.grizzly.http.util.Header;
 import org.glassfish.grizzly.http.util.HeaderValue;
+import org.glassfish.grizzly.http.util.HttpDateFormat;
 import org.glassfish.grizzly.http.util.HttpRequestURIDecoder;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http.util.MimeHeaders;
@@ -110,7 +110,7 @@ public class Response {
     /**
      * The date format we will use for creating date headers.
      */
-    protected SimpleDateFormat format = null;
+    protected DateTimeFormatter format = null;
 
     /**
      * Descriptive information about this Response implementation.
@@ -1019,11 +1019,10 @@ public class Response {
         }
 
         if (format == null) {
-            format = new SimpleDateFormat(HTTP_RESPONSE_DATE_HEADER, Locale.US);
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            format = DateTimeFormatter.ofPattern(HTTP_RESPONSE_DATE_HEADER, Locale.US).withZone(ZoneId.of("GMT"));
         }
 
-        addHeader(name, FastHttpDateFormat.formatDate(value, format));
+        addHeader(name, HttpDateFormat.formatDate(value, format));
 
     }
 
@@ -1042,11 +1041,10 @@ public class Response {
         }
 
         if (format == null) {
-            format = new SimpleDateFormat(HTTP_RESPONSE_DATE_HEADER, Locale.US);
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            format = DateTimeFormatter.ofPattern(HTTP_RESPONSE_DATE_HEADER, Locale.US).withZone(ZoneId.of("GMT"));
         }
 
-        addHeader(header, FastHttpDateFormat.formatDate(value, format));
+        addHeader(header, HttpDateFormat.formatDate(value, format));
 
     }
 
@@ -1331,11 +1329,10 @@ public class Response {
         }
 
         if (format == null) {
-            format = new SimpleDateFormat(HTTP_RESPONSE_DATE_HEADER, Locale.US);
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            format = DateTimeFormatter.ofPattern(HTTP_RESPONSE_DATE_HEADER, Locale.US).withZone(ZoneId.of("GMT"));
         }
 
-        setHeader(name, FastHttpDateFormat.formatDate(value, format));
+        setHeader(name, HttpDateFormat.formatDate(value, format));
 
     }
 
@@ -1355,11 +1352,10 @@ public class Response {
         }
 
         if (format == null) {
-            format = new SimpleDateFormat(HTTP_RESPONSE_DATE_HEADER, Locale.US);
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            format = DateTimeFormatter.ofPattern(HTTP_RESPONSE_DATE_HEADER, Locale.US).withZone(ZoneId.of("GMT"));
         }
 
-        setHeader(header, FastHttpDateFormat.formatDate(value, format));
+        setHeader(header, HttpDateFormat.formatDate(value, format));
 
     }
 

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/AccessLogBuilder.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/AccessLogBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,7 +19,8 @@ package org.glassfish.grizzly.http.server.accesslog;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 
 import org.glassfish.grizzly.http.server.HttpServer;
@@ -34,8 +36,8 @@ import org.glassfish.grizzly.http.server.ServerConfiguration;
  * </p>
  *
  * <p>
- * If the {@linkplain #timeZone(TimeZone) time zone} is left unspecified, the {@link TimeZone#getDefault() default time
- * zone} will be used.
+ * If the {@linkplain #timeZone(ZoneId) time zone} is left unspecified, the {@link ZoneId#systemDefault() default zone
+ * id} will be used.
  * </p>
  *
  * @author <a href="mailto:pier@usrz.com">Pier Fumagalli</a>
@@ -168,7 +170,21 @@ public class AccessLogBuilder {
         }
         if (format instanceof ApacheLogFormat) {
             final ApacheLogFormat apacheFormat = (ApacheLogFormat) format;
-            format = new ApacheLogFormat(timeZone, apacheFormat.getFormat());
+            format = new ApacheLogFormat(timeZone.toZoneId(), apacheFormat.getFormat());
+            return this;
+        }
+        throw new IllegalStateException("TimeZone can not be set for " + format.getClass().getName());
+    }
+
+    /**
+     * Set the <em>time zone</em> that will be used to represent dates.
+     */
+    public AccessLogBuilder timeZone(final ZoneId zoneId) {
+        if (zoneId == null) {
+            throw new NullPointerException("Null zoneId");
+        }
+        if (format instanceof ApacheLogFormat apacheFormat) {
+            format = new ApacheLogFormat(zoneId, apacheFormat.getFormat());
             return this;
         }
         throw new IllegalStateException("TimeZone can not be set for " + format.getClass().getName());
@@ -226,7 +242,7 @@ public class AccessLogBuilder {
     }
 
     /**
-     * Set up automatic log-file rotation based on a specified {@link SimpleDateFormat} <em>pattern</em>.
+     * Set up automatic log-file rotation based on a specified {@link DateTimeFormatter} <em>pattern</em>.
      *
      * <p>
      * For example, if the file name specified at {@linkplain #AccessLogBuilder(File) construction} was

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
@@ -775,7 +775,7 @@ public class ApacheLogFormat implements AccessLogFormat {
             }
 
             final DateTimeFormatter format = dateTimeFormatter.withZone(timeZone);
-            return builder.append(format.format(Instant.ofEpochMilli(timeStamp.getTime())));
+            return builder.append(format.format(timeStamp.toInstant()));
         }
 
         @Override

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,7 +19,9 @@ package org.glassfish.grizzly.http.server.accesslog;
 
 import static java.util.logging.Level.WARNING;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -131,7 +134,7 @@ import org.glassfish.grizzly.http.util.MimeHeaders;
  * <ul>
  * <li>When "<code>format</code>" is left unspecified, the default <code>%t</code> format
  * <code>[yyyy/MMM/dd:HH:mm:ss Z]</code> is used</li>
- * <li>When "<code>format</code>" is specified, the given pattern <b>must</b> be a valid {@link SimpleDateFormat}
+ * <li>When "<code>format</code>" is specified, the given pattern <b>must</b> be a valid {@link DateTimeFormatter}
  * pattern.</li>
  * <li>When "<code>@timezone</code>" is left unspecified, the {@linkplain TimeZone#getDefault() default time zone} is
  * used.</li>
@@ -179,7 +182,7 @@ import org.glassfish.grizzly.http.util.MimeHeaders;
 public class ApacheLogFormat implements AccessLogFormat {
 
     /* The UTC time zone */
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private static final ZoneId UTC = ZoneId.of("UTC");
 
     /** A {@link String} representing our version of Apache's <em>common</em> format. */
     public static final String COMMON_FORMAT = "%h - %u %t \"%r\" %s %b";
@@ -245,13 +248,13 @@ public class ApacheLogFormat implements AccessLogFormat {
     private final List<Field> fields;
 
     /* Our timezone */
-    private final TimeZone timeZone;
+    private final ZoneId timeZone;
 
     /**
      * Create a new {@link ApacheLogFormat} instance by parsing the format from the specified {@link String}.
      */
     public ApacheLogFormat(String format) {
-        this(TimeZone.getDefault(), format);
+        this(ZoneId.systemDefault(), format);
     }
 
     /**
@@ -260,6 +263,18 @@ public class ApacheLogFormat implements AccessLogFormat {
     public ApacheLogFormat(TimeZone timeZone, String format) {
         if (timeZone == null) {
             throw new NullPointerException("Null time zone");
+        }
+        fields = new ArrayList<>();
+        this.timeZone = timeZone.toZoneId();
+        parse(format);
+    }
+
+    /**
+     * Create a new {@link ApacheLogFormat} instance by parsing the format from the specified {@link String}.
+     */
+    public ApacheLogFormat(final ZoneId timeZone, final String format) {
+        if (timeZone == null) {
+            throw new NullPointerException("Null ZoneId");
         }
         fields = new ArrayList<>();
         this.timeZone = timeZone;
@@ -715,13 +730,13 @@ public class ApacheLogFormat implements AccessLogFormat {
 
     private static class RequestTimeField extends Field {
 
-        private static final String DEFAULT_PATTERN = "[yyyy/MMM/dd:HH:mm:ss Z]";
-        private final SimpleDateFormatThreadLocal simpleDateFormat;
-        private final TimeZone timeZone;
+        private static final String DEFAULT_PATTERN = "'['yyyy/MMM/dd:HH:mm:ss Z']'";
+        private final DateTimeFormatter dateTimeFormatter;
+        private final ZoneId timeZone;
         private final String pattern;
         private final String format;
 
-        RequestTimeField(String format, TimeZone zone) {
+        RequestTimeField(String format, ZoneId zone) {
             this.format = format;
             if (format == null) {
                 pattern = DEFAULT_PATTERN;
@@ -738,17 +753,19 @@ public class ApacheLogFormat implements AccessLogFormat {
                 } else if (pos == 0) {
                     /* We have *ONLY* a time zone specified */
                     pattern = DEFAULT_PATTERN;
-                    timeZone = TimeZone.getTimeZone(format.substring(1));
+                    // For compatibility with old TimeZone formatting, we use TimeZone here instead of ZoneId. For example, JST, PST
+                    timeZone = TimeZone.getTimeZone(format.substring(1)).toZoneId();
 
                 } else {
                     /* We have both format and time zone */
                     pattern = format.substring(0, pos).replace("@@", "@");
-                    timeZone = TimeZone.getTimeZone(format.substring(pos + 1));
+                    // For compatibility with old TimeZone formatting, we use TimeZone here instead of ZoneId. For example, JST, PST
+                    timeZone = TimeZone.getTimeZone(format.substring(pos + 1)).toZoneId();
                 }
             }
 
-            /* Get our simple date format */
-            simpleDateFormat = new SimpleDateFormatThreadLocal(pattern);
+            /* Get our date time formatter */
+            dateTimeFormatter = DateTimeFormatter.ofPattern(pattern);
         }
 
         @Override
@@ -757,9 +774,8 @@ public class ApacheLogFormat implements AccessLogFormat {
                 return builder.append('-');
             }
 
-            final SimpleDateFormat format = simpleDateFormat.get();
-            format.setTimeZone(timeZone);
-            return builder.append(format.format(timeStamp));
+            final DateTimeFormatter format = dateTimeFormatter.withZone(timeZone);
+            return builder.append(format.format(Instant.ofEpochMilli(timeStamp.getTime())));
         }
 
         @Override

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/SimpleDateFormatThreadLocal.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/SimpleDateFormatThreadLocal.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,6 +26,7 @@ import java.text.SimpleDateFormat;
  * @author <a href="mailto:pier@usrz.com">Pier Fumagalli</a>
  * @author <a href="http://www.usrz.com/">USRZ.com</a>
  */
+@Deprecated
 class SimpleDateFormatThreadLocal extends ThreadLocal<SimpleDateFormat> {
 
     private final SimpleDateFormat format;

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/filecache/FileCache.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/filecache/FileCache.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -41,10 +42,10 @@ import org.glassfish.grizzly.http.CompressionConfig;
 import org.glassfish.grizzly.http.HttpRequestPacket;
 import org.glassfish.grizzly.http.HttpResponsePacket;
 import org.glassfish.grizzly.http.Method;
-import org.glassfish.grizzly.http.server.util.SimpleDateFormats;
+import org.glassfish.grizzly.http.server.util.DateTimeFormatters;
 import org.glassfish.grizzly.http.util.ContentType;
-import org.glassfish.grizzly.http.util.FastHttpDateFormat;
 import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpDateFormat;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.glassfish.grizzly.localization.LogMessages;
@@ -973,11 +974,11 @@ public class FileCache implements MonitoringAware<FileCacheProbe> {
             return -1L;
         }
 
-        final SimpleDateFormats formats = SimpleDateFormats.create();
+        final DateTimeFormatters formats = DateTimeFormatters.create();
 
         try {
             // Attempt to convert the date header in a variety of formats
-            long result = FastHttpDateFormat.parseDate(dateHeader, formats.getFormats());
+            long result = HttpDateFormat.parseDate(dateHeader, formats.getFormats());
             if (result != -1L) {
                 return result;
             }

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/DateTimeFormatters.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/DateTimeFormatters.java
@@ -36,18 +36,18 @@ public final class DateTimeFormatters {
         return new DateTimeFormatters();
     }
 
-    private final DateTimeFormatter[] f;
+    private final DateTimeFormatter[] formatters;
 
-    public DateTimeFormatters() {
+    private DateTimeFormatters() {
         final ZoneId zoneId = ZoneId.of("GMT");
-        f = new DateTimeFormatter[]{
+        formatters = new DateTimeFormatter[]{
                 DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(zoneId),
                 DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss zzz", Locale.US).withZone(zoneId),
                 DateTimeFormatter.ofPattern("EEE MMMM d HH:mm:ss yyyy", Locale.US).withZone(zoneId)};
     }
 
     public DateTimeFormatter[] getFormats() {
-        return f;
+        return formatters;
     }
 
     public void recycle() {

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/DateTimeFormatters.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/DateTimeFormatters.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http.server.util;
+
+import org.glassfish.grizzly.ThreadCache;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class DateTimeFormatters {
+    private static final ThreadCache.CachedTypeIndex<DateTimeFormatters> CACHE_IDX = ThreadCache.obtainIndex(
+            DateTimeFormatters.class, 1);
+
+    public static DateTimeFormatters create() {
+        final DateTimeFormatters formats = ThreadCache.takeFromCache(CACHE_IDX);
+        if (formats != null) {
+            return formats;
+        }
+
+        return new DateTimeFormatters();
+    }
+
+    private final DateTimeFormatter[] f;
+
+    public DateTimeFormatters() {
+        final ZoneId zoneId = ZoneId.of("GMT");
+        f = new DateTimeFormatter[]{
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(zoneId),
+                DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss zzz", Locale.US).withZone(zoneId),
+                DateTimeFormatter.ofPattern("EEE MMMM d HH:mm:ss yyyy", Locale.US).withZone(zoneId)};
+    }
+
+    public DateTimeFormatter[] getFormats() {
+        return f;
+    }
+
+    public void recycle() {
+        ThreadCache.putToCache(CACHE_IDX, this);
+    }
+}

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/SimpleDateFormats.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/SimpleDateFormats.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,6 +23,7 @@ import java.util.TimeZone;
 
 import org.glassfish.grizzly.ThreadCache;
 
+@Deprecated
 public final class SimpleDateFormats {
     private static final ThreadCache.CachedTypeIndex<SimpleDateFormats> CACHE_IDX = ThreadCache.obtainIndex(SimpleDateFormats.class, 1);
 

--- a/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/FileCacheTest.java
+++ b/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/FileCacheTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -29,7 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -958,11 +961,9 @@ public class FileCacheTest {
     }
 
     private static String convertToDate(final long date) {
-
-        SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-        format.setTimeZone(TimeZone.getTimeZone("GMT"));
-        return format.format(new Date(date));
-
+        final DateTimeFormatter format =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
+        return format.format(Instant.ofEpochMilli(date));
     }
 
     private static File createTempFile() throws IOException {

--- a/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
+++ b/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Contributors to the Eclipse Foundation.
+ * Copyright 2021, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,6 +25,7 @@ import static org.glassfish.grizzly.http.Method.GET;
 import static org.glassfish.grizzly.http.Protocol.HTTP_1_1;
 import static org.junit.Assert.assertEquals;
 
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -35,7 +36,6 @@ import org.glassfish.grizzly.http.HttpResponsePacket;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
 import org.glassfish.grizzly.http.util.MimeHeaders;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -133,7 +133,6 @@ public class ApacheLogFormatTest {
     }
 
     @Test
-    @Ignore
     public void testBasicFormats() {
         final Response response = mockSimpleResponse();
         Locale.setDefault(Locale.US);
@@ -153,7 +152,6 @@ public class ApacheLogFormatTest {
     }
 
     @Test
-    @Ignore
     public void testBasicFormatsEmptyResponse() {
         final Response response = mockEmptyResponse();
 
@@ -166,14 +164,12 @@ public class ApacheLogFormatTest {
     }
 
     @Test
-    @Ignore
     public void testEscapes() {
         final Response response = mockSimpleResponse();
         assertEquals(new ApacheLogFormat("%%\\t\\b\\n\\r\\f\\%").unsafeFormat(response, date, nanos), "%\t\b\n\r\f%");
     }
 
     @Test
-    @Ignore
     public void testPatterns() {
         final Response response = mockSimpleResponse();
 
@@ -250,7 +246,6 @@ public class ApacheLogFormatTest {
     }
 
     @Test
-    @Ignore
     public void testPatternsEmptyResponse() {
         final Response response = mockEmptyResponse();
 
@@ -324,10 +319,9 @@ public class ApacheLogFormatTest {
     }
 
     @Test
-    @Ignore
     public void testDates() {
-        final TimeZone utc = TimeZone.getTimeZone("UTC");
-        final TimeZone jst = TimeZone.getTimeZone("JST");
+        final ZoneId utc = ZoneId.of("UTC");
+        final ZoneId jst = TimeZone.getTimeZone("JST").toZoneId();
         final Response response = mockEmptyResponse();
 
         assertEquals(new ApacheLogFormat(utc, "%t").unsafeFormat(response, date, nanos), "[2014/Jan/15:23:45:12 +0000]");

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -39,8 +39,8 @@ import org.glassfish.grizzly.http.Method.PayloadExpectation;
 import org.glassfish.grizzly.http.util.Constants;
 import org.glassfish.grizzly.http.util.ContentType;
 import org.glassfish.grizzly.http.util.DataChunk;
-import org.glassfish.grizzly.http.util.FastHttpDateFormat;
 import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpDateFormat;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http.util.HttpUtils;
 import org.glassfish.grizzly.http.util.MimeHeaders;
@@ -875,7 +875,7 @@ public class HttpServerFilter extends HttpCodecFilter {
         }
 
         if (!response.containsHeader(Header.Date)) {
-            response.getHeaders().addValue(Header.Date).setBytes(FastHttpDateFormat.getCurrentDateBytes());
+            response.getHeaders().addValue(Header.Date).setBytes(HttpDateFormat.getCurrentDateBytes());
         }
 
         final ProcessingState state = response.getProcessingState();

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderGenerator.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright 2004, 2022 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,12 @@
  */
 package org.glassfish.grizzly.http.util;
 
-import java.text.DateFormat;
-import java.text.FieldPosition;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.BitSet;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * <p>Cookie header generator based on RFC6265</p>
@@ -44,14 +42,10 @@ public class CookieHeaderGenerator {
 
     private static final String COOKIE_DATE_PATTERN = "EEE, dd-MMM-yyyy HH:mm:ss z";
 
-    protected static final ThreadLocal<DateFormat> COOKIE_DATE_FORMAT =
-        ThreadLocal.withInitial(() -> {
-            DateFormat dateFormat = new SimpleDateFormat(COOKIE_DATE_PATTERN, Locale.US);
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-            return dateFormat;
-        });
+    protected static final DateTimeFormatter COOKIE_DATE_FORMAT =
+            DateTimeFormatter.ofPattern(COOKIE_DATE_PATTERN, Locale.US).withZone(ZoneId.of("GMT"));
 
-    protected static final String ANCIENT_DATE = COOKIE_DATE_FORMAT.get().format(new Date(10000));
+    protected static final String ANCIENT_DATE = COOKIE_DATE_FORMAT.format(Instant.ofEpochMilli(10000));
 
     private static final BitSet domainValid = new BitSet(128);
 
@@ -109,12 +103,7 @@ public class CookieHeaderGenerator {
                 if (maxAge == 0) {
                     header.append(ANCIENT_DATE);
                 } else {
-                    COOKIE_DATE_FORMAT
-                        .get()
-                        .format(
-                            new Date(System.currentTimeMillis() + maxAge * 1000L),
-                            header,
-                            new FieldPosition(0));
+                    header.append(COOKIE_DATE_FORMAT.format(Instant.now().plusSeconds(maxAge)));
                 }
             }
         }

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieParserUtils.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieParserUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -26,8 +27,9 @@ import static org.glassfish.grizzly.http.util.CookieUtils.getTokenEndPosition;
 import static org.glassfish.grizzly.http.util.CookieUtils.isSeparator;
 import static org.glassfish.grizzly.http.util.CookieUtils.isWhiteSpace;
 
-import java.text.ParseException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -907,10 +909,10 @@ public class CookieParserUtils {
                         pos = valueEnd + 1;
 
                         final String expiresDate = new String(bytes, valueStart, valueEnd - valueStart, Charsets.ASCII_CHARSET);
-
-                        final Date date = OLD_COOKIE_FORMAT.get().parse(expiresDate);
-                        cookie.setMaxAge(getMaxAgeDelta(date.getTime(), System.currentTimeMillis()) / 1000);
-                    } catch (ParseException ignore) {
+                        cookie.setMaxAge(getMaxAgeDelta(
+                                ZonedDateTime.parse(expiresDate, OLD_COOKIE_FORMAT).toInstant().toEpochMilli(),
+                                Instant.now().toEpochMilli()) / 1000);
+                    } catch (DateTimeParseException ignore) {
                     }
 
                     continue;
@@ -1150,9 +1152,10 @@ public class CookieParserUtils {
                         pos = valueEnd + 1;
 
                         final String expiresDate = buffer.toStringContent(Charsets.ASCII_CHARSET, valueStart, valueEnd);
-                        final Date date = OLD_COOKIE_FORMAT.get().parse(expiresDate);
-                        cookie.setMaxAge(getMaxAgeDelta(date.getTime(), System.currentTimeMillis()) / 1000);
-                    } catch (ParseException ignore) {
+                        cookie.setMaxAge(getMaxAgeDelta(
+                                ZonedDateTime.parse(expiresDate, OLD_COOKIE_FORMAT).toInstant().toEpochMilli(),
+                                Instant.now().toEpochMilli()) / 1000);
+                    } catch (DateTimeParseException ignore) {
                     }
 
                     continue;
@@ -1385,9 +1388,10 @@ public class CookieParserUtils {
                         valueEnd = getTokenEndPosition(cookiesStr, valueEnd + 1, end, false);
                         pos = valueEnd + 1;
                         final String expiresDate = cookiesStr.substring(valueStart, valueEnd);
-                        final Date date = OLD_COOKIE_FORMAT.get().parse(expiresDate);
-                        cookie.setMaxAge(getMaxAgeDelta(date.getTime(), System.currentTimeMillis()) / 1000);
-                    } catch (ParseException ignore) {
+                        cookie.setMaxAge(getMaxAgeDelta(
+                                ZonedDateTime.parse(expiresDate, OLD_COOKIE_FORMAT).toInstant().toEpochMilli(),
+                                Instant.now().toEpochMilli()) / 1000);
+                    } catch (DateTimeParseException ignore) {
                     }
 
                     continue;

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieSerializerUtils.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieSerializerUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -28,7 +29,7 @@ import static org.glassfish.grizzly.http.util.CookieUtils.isToken2;
 import static org.glassfish.grizzly.http.util.CookieUtils.tspecials2NoSlash;
 
 import java.nio.BufferOverflowException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.http.Cookie;
@@ -98,7 +99,7 @@ public class CookieSerializerUtils {
                 if (maxAge == 0) {
                     buf.append(ancientDate);
                 } else {
-                    buf.append(OLD_COOKIE_FORMAT.get().format(new Date(System.currentTimeMillis() + maxAge * 1000L)));
+                    buf.append(OLD_COOKIE_FORMAT.format(Instant.now().plusSeconds(maxAge)));
                 }
 
             }
@@ -188,7 +189,7 @@ public class CookieSerializerUtils {
                 if (maxAge == 0) {
                     put(buf, ancientDate);
                 } else {
-                    put(buf, OLD_COOKIE_FORMAT.get().format(new Date(System.currentTimeMillis() + maxAge * 1000L)));
+                    put(buf, OLD_COOKIE_FORMAT.format(Instant.now().plusSeconds(maxAge)));
                 }
 
             }

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieUtils.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -18,10 +18,10 @@
 
 package org.glassfish.grizzly.http.util;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import org.glassfish.grizzly.Buffer;
 
@@ -70,17 +70,10 @@ public final class CookieUtils {
 
     static final String OLD_COOKIE_PATTERN = "EEE, dd-MMM-yyyy HH:mm:ss z";
 
-    public static final ThreadLocal<SimpleDateFormat> OLD_COOKIE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+    public static final DateTimeFormatter OLD_COOKIE_FORMAT =
+            DateTimeFormatter.ofPattern(OLD_COOKIE_PATTERN, Locale.US).withZone(ZoneId.of("GMT"));
 
-        @Override
-        protected SimpleDateFormat initialValue() {
-            // old cookie pattern format
-            SimpleDateFormat f = new SimpleDateFormat(OLD_COOKIE_PATTERN, Locale.US);
-            f.setTimeZone(TimeZone.getTimeZone("GMT"));
-            return f;
-        }
-    };
-    static final String ancientDate = OLD_COOKIE_FORMAT.get().format(new Date(10000));
+    static final String ancientDate = OLD_COOKIE_FORMAT.format(Instant.ofEpochMilli(10000));
 
     static final String tspecials = ",; ";
     static final String tspecials2 = "()<>@,;:\\\"/[]?={} \t";

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/FastHttpDateFormat.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/FastHttpDateFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -39,6 +40,7 @@ import org.glassfish.grizzly.utils.Charsets;
  * @author Gustav Trede
  * @author Remy Maucherat
  */
+@Deprecated
 public final class FastHttpDateFormat {
 
     private static final String ASCII_CHARSET_NAME = Charsets.ASCII_CHARSET.name();

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpDateFormat.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpDateFormat.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http.util;
+
+import org.glassfish.grizzly.utils.Charsets;
+
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.glassfish.grizzly.http.util.HttpCodecUtils.toCheckedByteArray;
+
+/**
+ * Utility class to generate HTTP dates.
+ * This class is based on {@link FastHttpDateFormat},
+ * but uses java.time API instead of the old java.util.Date/Calendar and java.text.DateFormat/SimpleDateFormat API.
+ *
+ * @author Bongjae Chang
+ */
+public final class HttpDateFormat {
+
+    private static final String ASCII_CHARSET_NAME = Charsets.ASCII_CHARSET.name();
+
+    private static final int CACHE_SIZE = 1000;
+
+    private static final ZoneId GMT_ZONE_ID = ZoneId.of("GMT");
+
+    // Fri, 03 Oct 2025 04:47:00 GMT
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT_ZONE_ID);
+
+    private static final DateTimeFormatter[] FORMATTERS = new DateTimeFormatter[]{
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT_ZONE_ID),
+            DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss zzz", Locale.US).withZone(GMT_ZONE_ID),
+            DateTimeFormatter.ofPattern("EEE MMMM d HH:mm:ss yyyy", Locale.US).withZone(GMT_ZONE_ID)};
+
+    /**
+     * Instant on which the currentDate object was generated.
+     */
+    private static volatile long nextGeneration;
+
+    private static final AtomicBoolean isGeneratingNow = new AtomicBoolean();
+
+    /**
+     * Current formatted date as byte[].
+     */
+    private static volatile byte[] currentDateBytes;
+
+    /**
+     * Current formatted date.
+     */
+    private static volatile String cachedStringDate;
+    private static volatile byte[] dateBytesForCachedStringDate;
+
+    /**
+     * Formatter cache.
+     */
+    private static final ConcurrentMap<Long, String> formatCache = new ConcurrentHashMap<>(CACHE_SIZE, 0.75f, 64);
+
+    /**
+     * Parser cache.
+     */
+    private static final ConcurrentMap<String, Long> parseCache = new ConcurrentHashMap<>(CACHE_SIZE, 0.75f, 64);
+
+    // --------------------------------------------------------- Public Methods
+
+    /**
+     * Get the current date in HTTP format.
+     */
+    public static String getCurrentDate() {
+        final byte[] currentDateBytesNow = getCurrentDateBytes();
+        if (currentDateBytesNow != dateBytesForCachedStringDate) {
+            try {
+                cachedStringDate = new String(currentDateBytesNow, ASCII_CHARSET_NAME);
+                dateBytesForCachedStringDate = currentDateBytesNow;
+            } catch (UnsupportedEncodingException ignored) {
+                // should never reach this line
+            }
+        }
+        return cachedStringDate;
+    }
+
+    /**
+     * Get the current date in HTTP format.
+     */
+    public static byte[] getCurrentDateBytes() {
+        final long now = System.currentTimeMillis();
+        final long diff = now - nextGeneration;
+        if (diff > 0 && (diff > 5000 || isGeneratingNow.compareAndSet(false, true))) {
+            currentDateBytes = toCheckedByteArray(new StringBuilder(FORMATTER.format(Instant.ofEpochMilli(now))));
+            nextGeneration = now + 1000;
+            isGeneratingNow.set(false);
+        }
+        return currentDateBytes;
+    }
+
+    /**
+     * Get the HTTP format of the specified date.<br>
+     * http spec only requre second precision http://tools.ietf.org/html/rfc2616#page-20 <br>
+     * therefore we dont use the millisecond precision , but second . truncation is done in the same way for second
+     * precision in SimpleDateFormat:<br>
+     * (999 millisec. = 0 sec.)
+     *
+     * @param value in milli-seconds
+     * @param formatter the {@link DateTimeFormatter} used if cache value was not found
+     */
+    public static String formatDate(long value, DateTimeFormatter formatter) {
+        // truncating to second precision
+        // this way we optimally use the cache to only store needed http values
+        value = value / 1000 * 1000;
+        final Long longValue = value;
+        String cachedDate = formatCache.get(longValue);
+        if (cachedDate != null) {
+            return cachedDate;
+        }
+        String newDate = Objects.requireNonNullElse(formatter, FORMATTER).format(Instant.ofEpochMilli(value));
+        updateFormatCache(longValue, newDate);
+        return newDate;
+    }
+
+    /**
+     * Try to parse the given date as a HTTP date.
+     */
+    public static long parseDate(final String value, final DateTimeFormatter[] formatters) {
+        Long cachedDate = parseCache.get(value);
+        if (cachedDate != null) {
+            return cachedDate;
+        }
+        long date;
+        date = internalParseDate(value, Objects.requireNonNullElse(formatters, FORMATTERS));
+        if (date != -1) {
+            updateParseCache(value, date);
+        }
+        return date;
+    }
+
+    /**
+     * Parse date with given formatters.
+     */
+    private static long internalParseDate(final String value, final DateTimeFormatter[] formatters) {
+        for (final DateTimeFormatter formatter : formatters) {
+            try {
+                return ZonedDateTime.parse(value, formatter).toInstant().toEpochMilli();
+            } catch (DateTimeParseException ignore) {
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Update cache.
+     */
+    private static void updateFormatCache(Long key, String value) {
+        if (value == null) {
+            return;
+        }
+        if (formatCache.size() > CACHE_SIZE) {
+            formatCache.clear();
+        }
+        formatCache.put(key, value);
+    }
+
+    /**
+     * Update cache.
+     */
+    private static void updateParseCache(String key, Long value) {
+        if (parseCache.size() > CACHE_SIZE) {
+            parseCache.clear();
+        }
+        parseCache.put(key, value);
+    }
+}

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/CookiesTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/CookiesTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,8 +18,10 @@
 package org.glassfish.grizzly.http;
 
 import java.nio.ByteBuffer;
-import java.text.ParseException;
-import java.util.Date;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.http.util.CookieUtils;
@@ -63,9 +66,9 @@ public class CookiesTest extends TestCase {
                                 new Checker(1, "/acme", CheckValue.PATH), new Checker(1, 1, CheckValue.VERSION) }) };
     }
 
-    private static final long IN_HOUR = System.currentTimeMillis() + 1000 * 60 * 60;
     // ex. Wednesday, 09-Nov-99 23:12:40 GMT
-    private static final String expiresStr = CookieUtils.OLD_COOKIE_FORMAT.get().format(new Date(IN_HOUR));
+    private static final String expiresStr =
+            CookieUtils.OLD_COOKIE_FORMAT.format(Instant.now().plusMillis(1000 * 60 * 60));
 
     private static Pair[] createServerTestCaseCookie() {
         return new Pair[] {
@@ -295,8 +298,10 @@ public class CookiesTest extends TestCase {
 
     private static int expire2MaxAge(String expire) {
         try {
-            return (int) (CookieUtils.OLD_COOKIE_FORMAT.get().parse(expire).getTime() - System.currentTimeMillis()) / 1000;
-        } catch (ParseException ex) {
+            return (int) Duration.between(Instant.now(),
+                                          ZonedDateTime.parse(expire, CookieUtils.OLD_COOKIE_FORMAT).toInstant())
+                                 .toSeconds();
+        } catch (DateTimeParseException ex) {
             throw new IllegalArgumentException("Illegal expire value: " + expire);
         }
     }

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/util/HttpDateFormatTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/util/HttpDateFormatTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.fail;
 public class HttpDateFormatTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testHttpDateFormat() {
         final long now = Instant.now().toEpochMilli();
         assertEquals(FastHttpDateFormat.formatDate(now, null), HttpDateFormat.formatDate(now, null));
@@ -103,6 +104,7 @@ public class HttpDateFormatTest {
 
     @Test
     @Ignore("Performance test")
+    @SuppressWarnings("deprecation")
     public void testHttpDateFormatForPerformance() {
         final int repeatCount = 2;
         int numberOfThreads = 512;

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/util/HttpDateFormatTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/util/HttpDateFormatTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http.util;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class HttpDateFormatTest {
+
+    @Test
+    public void testHttpDateFormat() {
+        final long now = Instant.now().toEpochMilli();
+        assertEquals(FastHttpDateFormat.formatDate(now, null), HttpDateFormat.formatDate(now, null));
+
+        final String sampleDate = "Fri, 03 Oct 2025 04:47:00 GMT";
+        assertEquals(FastHttpDateFormat.parseDate(sampleDate, null), HttpDateFormat.parseDate(sampleDate, null));
+
+        // check initial current date
+        boolean equalResult = false;
+        for (int i = 0; i < 2; i++) {
+            final Object[] initDates = performSimultaneously(
+                    new Supplier[]{FastHttpDateFormat::getCurrentDateBytes, HttpDateFormat::getCurrentDateBytes});
+            assertEquals(2, initDates.length);
+            equalResult = Arrays.equals((byte[]) initDates[0], (byte[]) initDates[1]);
+            if (equalResult) {
+                break;
+            }
+            // wait for 1 seconds to try again
+            try {
+                Thread.sleep(1001L);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        assertTrue(equalResult);
+        final String initFastDate = FastHttpDateFormat.getCurrentDate();
+        final String initHttpDate = HttpDateFormat.getCurrentDate();
+        assertEquals(initFastDate, initHttpDate);
+
+        // wait for 1 seconds(next generation) to see the difference in current date
+        try {
+            Thread.sleep(1001L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // check re-generated current date
+        equalResult = false;
+        for (int i = 0; i < 2; i++) {
+            final Object[] initDates = performSimultaneously(
+                    new Supplier[]{FastHttpDateFormat::getCurrentDateBytes, HttpDateFormat::getCurrentDateBytes});
+            assertEquals(2, initDates.length);
+            equalResult = Arrays.equals((byte[]) initDates[0], (byte[]) initDates[1]);
+            if (equalResult) {
+                break;
+            }
+            // wait for 1 seconds to try again
+            try {
+                Thread.sleep(1001L);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        assertTrue(equalResult);
+        final String currentFastDate = FastHttpDateFormat.getCurrentDate();
+        final String currentHttpDate = HttpDateFormat.getCurrentDate();
+        assertEquals(currentFastDate, currentHttpDate);
+
+        assertNotEquals(initHttpDate, currentHttpDate);
+        assertTrue(HttpDateFormat.parseDate(initHttpDate, null) < HttpDateFormat.parseDate(currentHttpDate, null));
+    }
+
+    @Test
+    @Ignore("Performance test")
+    public void testHttpDateFormatForPerformance() {
+        final int repeatCount = 2;
+        int numberOfThreads = 512;
+        int numberOfTryCountPerThread = 10000;
+        for (int i = 0; i < repeatCount; i++) {
+            System.out.println("Performance test iteration #" + (i + 1));
+            long timeElapsed = getMeasureTimeInMillis(numberOfThreads, numberOfTryCountPerThread,
+                                                      j -> FastHttpDateFormat.getCurrentDateBytes());
+            System.out.println("Time elapsed for FastHttpDateFormat with " + numberOfThreads + " threads and " +
+                               numberOfTryCountPerThread + " tries per thread: " + timeElapsed + " ms");
+            timeElapsed = getMeasureTimeInMillis(numberOfThreads, numberOfTryCountPerThread,
+                                                 j -> HttpDateFormat.getCurrentDateBytes());
+            System.out.println("Time elapsed for HttpDateFormat with " + numberOfThreads + " threads and " +
+                               numberOfTryCountPerThread + " tries per thread: " + timeElapsed + " ms");
+        }
+
+        // with some sleep time in each loop
+        final long sleepTimeInMillis = 50L;
+        numberOfThreads = 192;
+        numberOfTryCountPerThread = 15;
+        for (int i = 0; i < repeatCount; i++) {
+            System.out.println(
+                    "Performance test with " + sleepTimeInMillis + " ms sleep in each loop, iteration #" + (i + 1));
+            long timeElapsed = getMeasureTimeInMillis(numberOfThreads, numberOfTryCountPerThread, j -> {
+                FastHttpDateFormat.getCurrentDateBytes();
+                try {
+                    Thread.sleep(sleepTimeInMillis);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            System.out.println("Time elapsed for FastHttpDateFormat with " + numberOfThreads + " threads and " +
+                               numberOfTryCountPerThread + " tries per thread: " + timeElapsed + " ms");
+            timeElapsed = getMeasureTimeInMillis(numberOfThreads, numberOfTryCountPerThread, j -> {
+                HttpDateFormat.getCurrentDateBytes();
+                try {
+                    Thread.sleep(sleepTimeInMillis);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            System.out.println("Time elapsed for HttpDateFormat with " + numberOfThreads + " threads and " +
+                               numberOfTryCountPerThread + " tries per thread: " + timeElapsed + " ms");
+        }
+    }
+
+    private static Object[] performSimultaneously(final Supplier[] actions) {
+        if (actions == null || actions.length == 0) {
+            return new Object[0];
+        }
+        final CountDownLatch latch = new CountDownLatch(actions.length);
+        return Stream.of(actions).parallel().map(action -> {
+            latch.countDown();
+            try {
+                assertTrue(latch.await(3000L, TimeUnit.MILLISECONDS));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return action.get();
+        }).toList().toArray(new Object[0]);
+    }
+
+    private static long getMeasureTimeInMillis(final int numberOfThreads, final int numberOfTryCountPerThread,
+                                               final IntConsumer action) {
+        final Instant start = Instant.now();
+        // Each thread tries to set/get/remove each attribute multiple times.
+        final CompletableFuture[] futures = IntStream.range(0, numberOfThreads).mapToObj(
+                                                             i -> CompletableFuture.runAsync(() -> IntStream.range(0, numberOfTryCountPerThread).forEach(action)))
+                                                     .toArray(CompletableFuture[]::new);
+        try {
+            CompletableFuture.allOf(futures).orTimeout(60, TimeUnit.SECONDS).join();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        final Instant finish = Instant.now();
+        return Duration.between(start, finish).toMillis();
+    }
+}

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
@@ -63,8 +64,8 @@ import org.glassfish.grizzly.http.Method;
 import org.glassfish.grizzly.http.Protocol;
 import org.glassfish.grizzly.http.server.http2.PushEvent;
 import org.glassfish.grizzly.http.util.DataChunk;
-import org.glassfish.grizzly.http.util.FastHttpDateFormat;
 import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpDateFormat;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http2.NetLogger.Context;
 import org.glassfish.grizzly.http2.frames.ErrorCode;
@@ -882,7 +883,7 @@ public class Http2ServerFilter extends Http2BaseFilter {
         }
 
         if (!response.containsHeader(Header.Date)) {
-            response.getHeaders().addValue(Header.Date).setBytes(FastHttpDateFormat.getCurrentDateBytes());
+            response.getHeaders().addValue(Header.Date).setBytes(HttpDateFormat.getCurrentDateBytes());
         }
     }
 

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/FileCacheTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/FileCacheTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,12 +27,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Random;
-import java.util.TimeZone;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedTransferQueue;
@@ -394,9 +395,9 @@ public class FileCacheTest extends AbstractHttp2Test {
 
     private static String convertToDate(final long date) {
 
-        SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-        format.setTimeZone(TimeZone.getTimeZone("GMT"));
-        return format.format(new Date(date));
+        final DateTimeFormatter format =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(ZoneId.of("GMT"));
+        return format.format(Instant.ofEpochMilli(date));
 
     }
 


### PR DESCRIPTION
java.text.SimpleDateFormat is now deprecated in Grizzly and ThreadLocal, which was used with SimpleDateFormat, has also been removed.

+ Applied to Cookie utilities.
+ Added HttpDateFormat, which replaces FastHttpDateFormat.
+ Added DateTimeFormatters, which replace SimpleDateFormats.
+ Applied to http/http2/http-server modules.
+ Re-enabled ApacheLogFormatTest, which was ignored in the JDK17 build.