### PR TITLE
Remove CometContext's ThreadLocal(REQUEST_LOCAL)

### DIFF
--- a/modules/comet/src/main/java/org/glassfish/grizzly/comet/CometAddOn.java
+++ b/modules/comet/src/main/java/org/glassfish/grizzly/comet/CometAddOn.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,15 +17,10 @@
 
 package org.glassfish.grizzly.comet;
 
-import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.filterchain.FilterChainBuilder;
 import org.glassfish.grizzly.http.server.AddOn;
-import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
-import org.glassfish.grizzly.http.server.HttpServerFilter;
-import org.glassfish.grizzly.http.server.HttpServerProbe;
 import org.glassfish.grizzly.http.server.NetworkListener;
-import org.glassfish.grizzly.http.server.Request;
 
 /**
  * Comet {@link AddOn} for the {@link HttpServer}.
@@ -35,16 +31,6 @@ public class CometAddOn implements AddOn {
 
     @Override
     public void setup(final NetworkListener networkListener, final FilterChainBuilder builder) {
-
-        final int httpServerFilterIdx = builder.indexOfType(HttpServerFilter.class);
-        final HttpServerFilter httpServerFilter = (HttpServerFilter) builder.get(httpServerFilterIdx);
-        httpServerFilter.getMonitoringConfig().addProbes(new HttpServerProbe.Adapter() {
-            @Override
-            public void onBeforeServiceEvent(final HttpServerFilter filter, final Connection connection, final Request request, final HttpHandler httpHandler) {
-                CometContext.REQUEST_LOCAL.set(request);
-            }
-        });
-
         CometEngine.getEngine().setCometSupported(true);
     }
 }

--- a/modules/comet/src/main/java/org/glassfish/grizzly/comet/CometContext.java
+++ b/modules/comet/src/main/java/org/glassfish/grizzly/comet/CometContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -97,8 +98,6 @@ public class CometContext<E> {
             + " invoking that method is the same as the Servlet.service() thread.";
     protected final static Logger LOGGER = Logger.getLogger(CometContext.class.getName());
     private final Map<Object, Object> attributes;
-
-    protected final static ThreadLocal<Request> REQUEST_LOCAL = new ThreadLocal<>();
 
     /**
      * The context path associated with this instance.
@@ -214,14 +213,13 @@ public class CometContext<E> {
      *
      * @return The hash code of the handler.
      */
-    public int addCometHandler(CometHandler<E> handler) {
+    public int addCometHandler(final Request request, CometHandler<E> handler) {
         if (handler == null) {
             throw new IllegalStateException(INVALID_COMET_HANDLER);
         }
         if (!CometEngine.getEngine().isCometEnabled()) {
             throw new IllegalStateException(COMET_NOT_ENABLED);
         }
-        final Request request = REQUEST_LOCAL.get();
         final Response response = request.getResponse();
         final Connection c = request.getContext().getConnection();
 

--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometHttpHandler.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometHttpHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -35,7 +36,7 @@ public class CometHttpHandler extends HttpHandler {
     @Override
     public void service(Request request, Response response) throws IOException {
         cometHandler = createHandler(response);
-        cometContext.addCometHandler(cometHandler);
+        cometContext.addCometHandler(request, cometHandler);
     }
 
     public DefaultTestCometHandler createHandler(Response response) {

--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometTestHttpHandler.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometTestHttpHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -41,7 +42,7 @@ public class CometTestHttpHandler extends HttpHandler {
 
     @Override
     public void service(Request req, Response res) {
-        cometContext.addCometHandler(useConcurrentCometHandler ? new MyConcurrentCometHandler(cometContext, res) : new CometRequestHandler());
+        cometContext.addCometHandler(req, useConcurrentCometHandler ? new MyConcurrentCometHandler(cometContext, res) : new CometRequestHandler());
     }
 
     private void doEvent(CometEvent event, CometHandler handler) throws IOException {


### PR DESCRIPTION
"Avoid using ThreadLocals for caching expensive resources" (https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2206)
+ Removed CometContext's REQUEST_LOCAL. 

The request is set to REQUEST_LOCAL via onBeforeServiceEvent() before calling CometHttpHandler#service(). Looking at the code, I see that this request is the same value passed to the service() call. Therefore, I'll modify it to use the request passed to the service() call directly.