### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometUnitTests.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/CometUnitTests.java
@@ -211,7 +211,7 @@ public class CometUnitTests /* extends TestCase */ {
                     if (b == -1) {
 //                        fail("server closed connection");
                     } else {
-//                        fail("client did not recieve expected message, got:'" + b + "'");
+//                        fail("client did not receive expected message, got:'" + b + "'");
                     }
                 }
                 if (!reuse) {

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/TransformationException.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/TransformationException.java
@@ -17,7 +17,7 @@
 package org.glassfish.grizzly;
 
 /**
- * Describes the problem, occured during original message transformation.
+ * Describes the problem, occurred during original message transformation.
  *
  * @author Alexey Stashok
  */

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainProcessorSelector.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/filterchain/FilterChainProcessorSelector.java
@@ -44,7 +44,7 @@ public class FilterChainProcessorSelector implements ProcessorSelector {
      * otherwise.
      *
      * @param ioEvent {@link IOEvent} to process.
-     * @param connection {@link Connection}, where {@link IOEvent} occured.
+     * @param connection {@link Connection}, where {@link IOEvent} occurred.
      *
      * @return {@link FilterChain} instance, if it's interested in processing passed {@link IOEvent}, or <tt>null</tt>
      * otherwise.

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/impl/UnsafeFutureImpl.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/impl/UnsafeFutureImpl.java
@@ -156,7 +156,7 @@ public final class UnsafeFutureImpl<R> implements FutureImpl<R> {
     }
 
     /**
-     * Notify about the failure, occured during asynchronous operation execution.
+     * Notify about the failure, occurred during asynchronous operation execution.
      *
      * @param failure
      */

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/SelectorRunner.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/SelectorRunner.java
@@ -415,7 +415,7 @@ public final class SelectorRunner implements Runnable {
     /**
      * Notify transport about the {@link Exception} happened, log it and cancel the {@link SelectionKey}, if it is not null
      *
-     * @param key {@link SelectionKey}, which was processed, when the {@link Exception} occured
+     * @param key {@link SelectionKey}, which was processed, when the {@link Exception} occurred
      * @param description error description
      * @param e {@link Exception} occurred
      * @param runLogLevel logger {@link Level} to use, if transport is in running state

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/GrizzlyExecutorService.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/GrizzlyExecutorService.java
@@ -87,7 +87,7 @@ public class GrizzlyExecutorService extends AbstractExecutorService implements M
      */
     public GrizzlyExecutorService reconfigure(ThreadPoolConfig config) {
         synchronized (statelock) {
-            // TODO: only create new pool if old one cant be runtime config
+            // TODO: only create new pool if old one can't be runtime config
             // for the needed state change(s).
             final AbstractThreadPool oldpool = this.pool;
             if (config.getQueue() == oldpool.getQueue()) {

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NetworkListener.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/NetworkListener.java
@@ -410,7 +410,7 @@ public class NetworkListener {
     }
 
     /**
-     * Return the array of the registered {@link AddOn}s. Please note, possible array modifications wont affect the
+     * Return the array of the registered {@link AddOn}s. Please note, possible array modifications won't affect the
      * {@link NetworkListener}'s addons list.
      *
      * @return the array of the registered {@link AddOn}s.
@@ -462,7 +462,7 @@ public class NetworkListener {
     }
 
     /**
-     * Enable/disable chunking of an HTTP response body if no content length has been explictly specified. Chunking is
+     * Enable/disable chunking of an HTTP response body if no content length has been explicitly specified. Chunking is
      * enabled by default.
      *
      * @param chunkingEnabled <code>true</code> to enable chunking; <code>false</code> to disable.

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/RequestExecutorProvider.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/RequestExecutorProvider.java
@@ -54,7 +54,7 @@ public interface RequestExecutorProvider {
      * The {@link RequestExecutorProvider} implementation, which checks if the current {@link Thread} is a service
      * {@link Thread} (see {@link Threads#isService()}). If the current {@link Thread} is a service {@link Thread} - the
      * implementation returns a worker thread pool associated with the {@link Request}, or, if the current {@link Thread} is
-     * not a service {@link Thread} - <tt>null</tt> will be return to force the user code to be executed on the current
+     * not a service {@link Thread} - <tt>null</tt> will be returned to force the user code to be executed on the current
      * {@link Thread}.
      */
     class WorkerThreadProvider implements RequestExecutorProvider {

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/Globals.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/util/Globals.java
@@ -94,7 +94,7 @@ public final class Globals {
     public static final String EXCEPTION_TYPE_ATTR = "jakarta.servlet.error.exception_type";
 
     /**
-     * The request attribute under which we forward an HTTP status message (as an object of type STring) to an error page.
+     * The request attribute under which we forward an HTTP status message (as an object of type String) to an error page.
      */
     public static final String ERROR_MESSAGE_ATTR = "jakarta.servlet.error.message";
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/FastHttpDateFormat.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/FastHttpDateFormat.java
@@ -174,8 +174,8 @@ public final class FastHttpDateFormat {
 
     /**
      * Get the HTTP format of the specified date.<br>
-     * http spec only requre second precision http://tools.ietf.org/html/rfc2616#page-20 <br>
-     * therefore we dont use the millisecond precision , but second . truncation is done in the same way for second
+     * http spec only require second precision http://tools.ietf.org/html/rfc2616#page-20 <br>
+     * therefore we don't use the millisecond precision , but second . truncation is done in the same way for second
      * precision in SimpleDateFormat:<br>
      * (999 millisec. = 0 sec.)
      * 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpDateFormat.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpDateFormat.java
@@ -130,8 +130,8 @@ public final class HttpDateFormat {
 
     /**
      * Get the HTTP format of the specified date.<br>
-     * http spec only requre second precision http://tools.ietf.org/html/rfc2616#page-20 <br>
-     * therefore we dont use the millisecond precision , but second . truncation is done in the same way for second
+     * http spec only require second precision http://tools.ietf.org/html/rfc2616#page-20 <br>
+     * therefore we don't use the millisecond precision , but second . truncation is done in the same way for second
      * precision in SimpleDateFormat:<br>
      * (999 millisec. = 0 sec.)
      *

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ClientFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ClientFilter.java
@@ -104,7 +104,7 @@ public class Http2ClientFilter extends Http2BaseFilter {
     }
 
     /**
-     * @return <tt>true</tt> if the push request has to be sent upstream, so a user have a chance to process it, or
+     * @return <tt>true</tt> if the push request has to be sent upstream, so a user has an opportunity to process it, or
      * <tt>false</tt> otherwise
      */
     public boolean isSendPushRequestUpstream() {
@@ -112,7 +112,7 @@ public class Http2ClientFilter extends Http2BaseFilter {
     }
 
     /**
-     * @param sendPushRequestUpstream <tt>true</tt> if the push request has to be sent upstream, so a user have a chance to
+     * @param sendPushRequestUpstream <tt>true</tt> if the push request has to be sent upstream, so a user has an opportunity to
      * process it, or <tt>false</tt> otherwise
      */
     public void setSendPushRequestUpstream(boolean sendPushRequestUpstream) {


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help