### PR TITLE
Replaced ee4j.grizzly to ee4j.glassfish 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,14 @@ management issues made it impossible for a server to scale to thousands of
 users. The Eclipse Grizzly NIO framework has been designed to help developers to
 take advantage of the Java™ NIO API.
 
-* https://projects.eclipse.org/projects/ee4j.grizzly
+* https://projects.eclipse.org/projects/ee4j.glassfish
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* https://projects.eclipse.org/projects/ee4j.grizzly/developer
+* https://projects.eclipse.org/projects/ee4j.glassfish/developer
 
 The project maintains the following source code repositories
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 This content is produced and maintained by the Eclipse Grizzly project.
 
-* Project home: https://projects.eclipse.org/projects/ee4j.grizzly
+* Project home: https://projects.eclipse.org/projects/ee4j.glassfish
 
 ## Trademarks
 
@@ -30,7 +30,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-ee4j/grizzly
+* https://github.com/eclipse-ee4j/glassfish-grizzly
 
 ## Third-party Content
 

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -32,7 +32,7 @@
     <packaging>bundle</packaging>
 
     <name>grizzly-http-ajp</name>
-    <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
+    <url>https://projects.eclipse.org/projects/ee4j.glassfish</url>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <packaging>pom</packaging>
 
     <name>grizzly-project</name>
-    <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
+    <url>https://projects.eclipse.org/projects/ee4j.glassfish</url>
     <organization>
         <name>Oracle Corporation</name>
         <url>http://www.oracle.com</url>


### PR DESCRIPTION
Because https://projects.eclipse.org/projects/ee4j.grizzly is archived.