### PR TITLE
Adjusted the log level for request parameters starting with the first ampersand

### DIFF
--- a/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
+++ b/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
@@ -86,7 +86,7 @@ severe.grizzly.comet.engine.invalid.notification-handler.error=GRIZZLY0103: Inva
 # ---------------------------------------------------------- Grizzly HTTP Module
 
 
-info.grizzly.http.parameters.invalidChunk=GRIZZLY0155: Invalid chunk starting at byte [{0}] and ending at byte [{1}] with a value of [{2}] ignored
+fine.grizzly.http.parameters.invalidChunk=GRIZZLY0155: Invalid chunk starting at byte [{0}] and ending at byte [{1}] with a value of [{2}] ignored
 info.grizzly.http.parameters.decodeFail.info=GRIZZLY0156: Character decoding failed. Cause: [{0}].\n    Parameter [{1}] with value [{2}] has been ignored.\n    Note that the name and value quoted here may be corrupted due to the failed decoding.\n    Use FINEST level logging to see the original, non-corrupted values.
 info.grizzly.http.parameters.multipleDecodingFail=GRIZZLY0157: Character decoding failed. A total of [{0}] failures were detected but only the first was logged. Enable debug level logging for this logger to log all failures.
 fine.grizzly.http.parameters.noequal=Parameter starting at position [{0}] and ending at position [{1}] with a value of [{2}] was not followed by an '=' character

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/Parameters.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/Parameters.java
@@ -446,9 +446,9 @@ public final class Parameters {
             }
 
             if (nameEnd <= nameStart) {
-                if (LOGGER.isLoggable(Level.INFO)) {
+                if (LOGGER.isLoggable(Level.FINE)) {
                     if (valueEnd < nameStart) {
-                        LOGGER.info(LogMessages.INFO_GRIZZLY_HTTP_PARAMETERS_INVALID_CHUNK(nameStart, nameEnd, null));
+                        LOGGER.fine(LogMessages.FINE_GRIZZLY_HTTP_PARAMETERS_INVALID_CHUNK(nameStart, nameEnd, null));
                     }
                 }
                 continue;

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ParametersTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ParametersTest.java
@@ -331,6 +331,18 @@ public class ParametersTest {
         params.processParameters(request);
     }
 
+    @Test
+    public void testFirstAmpersandParameters() {
+        final Parameters params = new Parameters();
+        final byte[] data = new byte[]{(byte) '&', (byte) 'k', (byte) '=', (byte) 'v'};
+        // ignore the first ampersand and parse the rest
+        params.processParameters(Buffers.wrap(MemoryManager.DEFAULT_MEMORY_MANAGER, data), 0, data.length);
+        final Set<String> names = params.getParameterNames();
+        assertNotNull(names);
+        assertEquals(1, names.size());
+        assertEquals("v", params.getParameter("k"));
+    }
+
     private void validateParameters(Parameter[] parameters, Parameters p) {
         Iterator<String> names = p.getParameterNames().iterator();
 


### PR DESCRIPTION
+ Change the INFO level to FINE level.
+ Added a test case that ignores the first ampersand and parses the following parameters normally.

If the request param begins with `&`, the following log message is generated at INFO level.

> INFO: GRIZZLY0155: Invalid chunk starting at byte [0] and ending at byte [0] with a value of [null] ignored

This message is not treated as an error; the first `&` is ignored and subsequent parameters are processed normally. Therefore, the FINE level seems more appropriate.