### PR TITLE
Fix Test scenarios that were failing in JDK 25

### DIFF
--- a/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
+++ b/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2025 Contributors to the Eclipse Foundation.
 # Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/Parameters.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/Parameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ParametersTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ParametersTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/AbstractHttp2Test.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/AbstractHttp2Test.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -154,11 +155,11 @@ public abstract class AbstractHttp2Test {
                     SSLContextConfigurator sslContextConfigurator = createSSLContextConfigurator();
                     serverSSLEngineConfigurator = new SSLEngineConfigurator(sslContextConfigurator.createSSLContext(true), false, false, false);
 
-                    serverSSLEngineConfigurator.setEnabledCipherSuites(new String[] { "TLS_RSA_WITH_AES_256_CBC_SHA" });
+                    serverSSLEngineConfigurator.setEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256" });
 
                     clientSSLEngineConfigurator = new SSLEngineConfigurator(sslContextConfigurator.createSSLContext(true), true, false, false);
 
-                    clientSSLEngineConfigurator.setEnabledCipherSuites(new String[] { "TLS_RSA_WITH_AES_256_CBC_SHA" });
+                    clientSSLEngineConfigurator.setEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256" });
                 }
             }
         }


### PR DESCRIPTION
- #2259 
  + Considered the java.io.IOException: Premature EOF error.
  + Changed to Cipher Suites that support TLS 1.3.
- #2258 
  + (Trivial) Added missing license headers.

All builds and testcases passed successfully on JDK 25.