### PR TITLE
Remove the part related to grizzly-npn-bootstrap

### DIFF
--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -128,36 +128,4 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <profiles>
-        <!-- Compatibility tests with other implementations of ALPN. New JDK implementations have their own. -->
-        <profile>
-            <id>openjsse</id>
-            <properties>
-                <bootClasspath>-Xbootclasspath/p:${settings.localRepository}/org/openjsse/openjsse/${openjsse.version}/openjsse-${openjsse.version}.jar</bootClasspath>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.openjsse</groupId>
-                    <artifactId>openjsse</artifactId>
-                    <version>${openjsse.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>npn</id>
-            <properties>
-                <bootClasspath>-Xbootclasspath/p:${settings.localRepository}/org/glassfish/grizzly/grizzly-npn-bootstrap/${grizzly.npn.bootstrap.version}/grizzly-npn-bootstrap-${grizzly.npn.bootstrap.version}.jar</bootClasspath>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.glassfish.grizzly</groupId>
-                    <artifactId>grizzly-npn-bootstrap</artifactId>
-                    <version>${grizzly.npn.bootstrap.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/AplnExtensionCompatibility.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/AplnExtensionCompatibility.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,7 +32,6 @@ class AplnExtensionCompatibility {
 
     private static AplnExtensionCompatibility INSTANCE;
 
-    private final boolean alpnExtensionGrizzly;
     private final boolean protocolSelectorSetterInApi;
     private final boolean protocolSelectorSetterInImpl;
 
@@ -44,12 +44,7 @@ class AplnExtensionCompatibility {
 
 
     public boolean isAlpnExtensionAvailable() {
-        return isAlpnExtensionGrizzly() || isProtocolSelectorSetterInApi() || isProtocolSelectorSetterInImpl();
-    }
-
-
-    public boolean isAlpnExtensionGrizzly() {
-        return alpnExtensionGrizzly;
+        return isProtocolSelectorSetterInApi() || isProtocolSelectorSetterInImpl();
     }
 
 
@@ -84,20 +79,8 @@ class AplnExtensionCompatibility {
 
 
     private AplnExtensionCompatibility() {
-        this.alpnExtensionGrizzly = isClassAvailableOnBootstrapClasspath("sun.security.ssl.GrizzlyNPN");
         this.protocolSelectorSetterInApi = isHandshakeSetterInApi();
         this.protocolSelectorSetterInImpl = isHandshakeSetterInImpl();
-    }
-
-
-    private static boolean isClassAvailableOnBootstrapClasspath(final String className) {
-        try {
-            ClassLoader.getSystemClassLoader().loadClass(className);
-            return true;
-        } catch (final ClassNotFoundException e) {
-            LOG.config("The class with the name '" + className + "' is not available on the bootstrap classpath.");
-            return false;
-        }
     }
 
 
@@ -122,7 +105,6 @@ class AplnExtensionCompatibility {
 
     private static boolean isHandshakeSetterInApi() {
         try {
-            // new grizzly bootstrap versions implement this method.
             SSLEngine.class.getMethod(METHOD_NAME, BiFunction.class);
             return true;
         } catch (final NoSuchMethodException e) {
@@ -137,7 +119,6 @@ class AplnExtensionCompatibility {
     @Override
     public String toString() {
         return super.toString() + "ALPN available: " + isAlpnExtensionAvailable()
-            + ", ALPN is Grizzly: " + isAlpnExtensionGrizzly()
             + ", setHandshakeApplicationProtocolSelector in API: " + isProtocolSelectorSetterInApi()
             + ", setHandshakeApplicationProtocolSelector in impl: " + isProtocolSelectorSetterInImpl();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -125,8 +125,6 @@
         <cobertura.version>2.4</cobertura.version>
         <gmbal.version>4.0.0</gmbal.version>
         <grizzly.npn.api.version>2.0.0</grizzly.npn.api.version>
-        <grizzly.npn.bootstrap.version>2.0.0</grizzly.npn.bootstrap.version>
-        <openjsse.version>1.1.5</openjsse.version>
         <osgi.version>4.2.0</osgi.version>
         <release.arguments></release.arguments>
     </properties>


### PR DESCRIPTION
The glassfish-grizzly-npn bootstrap module (grizzly-npn-bootstrap.jar) will no longer be provided in the next release.

- https://github.com/eclipse-ee4j/glassfish-grizzly-npn/issues/21#issuecomment-3377789443

Therefore, the bootstrap module-related parts will be removed from Grizzly.