### PR TITLE
Support monitoring in VirtualThreadExecutorService

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ProbeNotifier.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ProbeNotifier.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,11 +26,11 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "thread pool started" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    static void notifyThreadPoolStarted(final AbstractThreadPool threadPool) {
+    static void notifyThreadPoolStarted(final ThreadPoolInfo threadPool) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onThreadPoolStartEvent(threadPool);
@@ -40,11 +41,11 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "thread pool stopped" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    static void notifyThreadPoolStopped(final AbstractThreadPool threadPool) {
+    static void notifyThreadPoolStopped(final ThreadPoolInfo threadPool) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onThreadPoolStopEvent(threadPool);
@@ -55,12 +56,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "thread allocated" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param thread the thread that has been allocated
      */
-    static void notifyThreadAllocated(final AbstractThreadPool threadPool, final Thread thread) {
+    static void notifyThreadAllocated(final ThreadPoolInfo threadPool, final Thread thread) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onThreadAllocateEvent(threadPool, thread);
@@ -71,12 +72,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "thread released" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param thread the thread that has been allocated
      */
-    static void notifyThreadReleased(final AbstractThreadPool threadPool, final Thread thread) {
+    static void notifyThreadReleased(final ThreadPoolInfo threadPool, final Thread thread) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onThreadReleaseEvent(threadPool, thread);
@@ -87,12 +88,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "max number of threads reached" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
-     * @param maxNumberOfThreads the maximum number of threads allowed in the {@link AbstractThreadPool}
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
+     * @param maxNumberOfThreads the maximum number of threads allowed in the {@link ThreadPoolInfo}
      */
-    static void notifyMaxNumberOfThreads(final AbstractThreadPool threadPool, final int maxNumberOfThreads) {
+    static void notifyMaxNumberOfThreads(final ThreadPoolInfo threadPool, final int maxNumberOfThreads) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onMaxNumberOfThreadsEvent(threadPool, maxNumberOfThreads);
@@ -103,12 +104,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "task queued" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work to be processed
      */
-    static void notifyTaskQueued(final AbstractThreadPool threadPool, final Runnable task) {
+    static void notifyTaskQueued(final ThreadPoolInfo threadPool, final Runnable task) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onTaskQueueEvent(threadPool, task);
@@ -119,12 +120,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "task dequeued" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work to be processed
      */
-    static void notifyTaskDequeued(final AbstractThreadPool threadPool, final Runnable task) {
+    static void notifyTaskDequeued(final ThreadPoolInfo threadPool, final Runnable task) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onTaskDequeueEvent(threadPool, task);
@@ -135,12 +136,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "task cancelled" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work to be processed
      */
-    static void notifyTaskCancelled(final AbstractThreadPool threadPool, final Runnable task) {
+    static void notifyTaskCancelled(final ThreadPoolInfo threadPool, final Runnable task) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onTaskCancelEvent(threadPool, task);
@@ -151,12 +152,12 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "task completed" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work to be processed
      */
-    static void notifyTaskCompleted(final AbstractThreadPool threadPool, final Runnable task) {
+    static void notifyTaskCompleted(final ThreadPoolInfo threadPool, final Runnable task) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onTaskCompleteEvent(threadPool, task);
@@ -167,11 +168,11 @@ final class ProbeNotifier {
     /**
      * Notify registered {@link ThreadPoolProbe}s about the "task queue overflow" event.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    static void notifyTaskQueueOverflow(final AbstractThreadPool threadPool) {
+    static void notifyTaskQueueOverflow(final ThreadPoolInfo threadPool) {
 
-        final ThreadPoolProbe[] probes = threadPool.monitoringConfig.getProbesUnsafe();
+        final ThreadPoolProbe[] probes = threadPool.getMonitoringConfig().getProbesUnsafe();
         if (probes != null) {
             for (ThreadPoolProbe probe : probes) {
                 probe.onTaskQueueOverflowEvent(threadPool);

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ThreadPoolInfo.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ThreadPoolInfo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.grizzly.threadpool;
+
+import org.glassfish.grizzly.monitoring.DefaultMonitoringConfig;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public interface ThreadPoolInfo {
+
+    /**
+     * @return the number of allocated threads in the thread pool
+     */
+    int getSize();
+
+    /**
+     * @return the thread pool configuration
+     */
+    ThreadPoolConfig getConfig();
+
+    DefaultMonitoringConfig<ThreadPoolProbe> getMonitoringConfig();
+
+    boolean isShutdown();
+
+    int getQueueSize();
+
+}

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ThreadPoolProbe.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/ThreadPoolProbe.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,7 +18,7 @@
 package org.glassfish.grizzly.threadpool;
 
 /**
- * Monitoring probe providing callbacks that may be invoked by Grizzly {@link AbstractThreadPool} implementations.
+ * Monitoring probe providing callbacks that may be invoked by Grizzly {@link ThreadPoolInfo} implementations.
  *
  * @author gustav trede
  * @author Alexey Stashok
@@ -27,72 +28,72 @@ package org.glassfish.grizzly.threadpool;
 public interface ThreadPoolProbe {
     /**
      * <p>
-     * This event may be fired when an {@link AbstractThreadPool} implementation starts running.
+     * This event may be fired when an {@link ThreadPoolInfo} implementation starts running.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    void onThreadPoolStartEvent(AbstractThreadPool threadPool);
+    void onThreadPoolStartEvent(ThreadPoolInfo threadPool);
 
     /**
      * <p>
-     * This event may be fired when an {@link AbstractThreadPool} implementation stops.
+     * This event may be fired when an {@link ThreadPoolInfo} implementation stops.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    void onThreadPoolStopEvent(AbstractThreadPool threadPool);
+    void onThreadPoolStopEvent(ThreadPoolInfo threadPool);
 
     /**
      * <p>
-     * This event may be fired when an {@link AbstractThreadPool} implementation allocates a new managed {@link Thread}.
+     * This event may be fired when an {@link ThreadPoolInfo} implementation allocates a new managed {@link Thread}.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param thread the thread that has been allocated
      */
-    void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread);
+    void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread);
 
     /**
      * <p>
-     * This event may be fired when a thread will no longer be managed by the {@link AbstractThreadPool} implementation.
+     * This event may be fired when a thread will no longer be managed by the {@link ThreadPoolInfo} implementation.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
-     * @param thread the thread that is no longer being managed by the {@link AbstractThreadPool}
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
+     * @param thread the thread that is no longer being managed by the {@link ThreadPoolInfo}
      */
-    void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread);
+    void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread);
 
     /**
      * <p>
-     * This event may be fired when the {@link AbstractThreadPool} implementation has allocated and is managing a number of
+     * This event may be fired when the {@link ThreadPoolInfo} implementation has allocated and is managing a number of
      * threads equal to the maximum limit of the pool.
      * <p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
-     * @param maxNumberOfThreads the maximum number of threads allowed in the {@link AbstractThreadPool}
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
+     * @param maxNumberOfThreads the maximum number of threads allowed in the {@link ThreadPoolInfo}
      */
-    void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads);
+    void onMaxNumberOfThreadsEvent(ThreadPoolInfo threadPool, int maxNumberOfThreads);
 
     /**
      * <p>
      * This event may be fired when a task has been queued for processing.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work to be processed
      */
-    void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task);
+    void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task);
 
     /**
      * <p>
      * This event may be fired when a task has been pulled from the queue and is about to be processed.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work that is about to be processed.
      */
-    void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task);
+    void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task);
 
     /**
      * <p>
@@ -101,30 +102,30 @@ public interface ThreadPoolProbe {
      * This event can occur during shutdownNow() invocation, where tasks are getting pulled out of thread pool queue and
      * returned as the result of shutdownNow() method call.
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task a unit of work that has been canceled
      */
-    void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task);
+    void onTaskCancelEvent(ThreadPoolInfo threadPool, Runnable task);
 
     /**
      * <p>
      * This event may be fired when a dequeued task has completed processing.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      * @param task the unit of work that has completed processing
      */
-    void onTaskCompleteEvent(AbstractThreadPool threadPool, Runnable task);
+    void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task);
 
     /**
      * <p>
-     * This event may be fired when the task queue of the {@link AbstractThreadPool} implementation has exceeded its
+     * This event may be fired when the task queue of the {@link ThreadPoolInfo} implementation has exceeded its
      * configured size.
      * </p>
      *
-     * @param threadPool the {@link AbstractThreadPool} being monitored
+     * @param threadPool the {@link ThreadPoolInfo} being monitored
      */
-    void onTaskQueueOverflowEvent(AbstractThreadPool threadPool);
+    void onTaskQueueOverflowEvent(ThreadPoolInfo threadPool);
 
     // ---------------------------------------------------------- Nested Classes
 
@@ -143,70 +144,70 @@ public interface ThreadPoolProbe {
          * {@inheritDoc}
          */
         @Override
-        public void onThreadPoolStartEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStartEvent(ThreadPoolInfo threadPool) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onThreadPoolStopEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStopEvent(ThreadPoolInfo threadPool) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads) {
+        public void onMaxNumberOfThreadsEvent(ThreadPoolInfo threadPool, int maxNumberOfThreads) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCancelEvent(ThreadPoolInfo threadPool, Runnable task) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onTaskCompleteEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task) {
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public void onTaskQueueOverflowEvent(AbstractThreadPool threadPool) {
+        public void onTaskQueueOverflowEvent(ThreadPoolInfo threadPool) {
         }
 
     } // END Adapter

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/VirtualThreadExecutorService.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/threadpool/VirtualThreadExecutorService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package org.glassfish.grizzly.threadpool;
 
 import org.glassfish.grizzly.Grizzly;
@@ -12,19 +27,38 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.glassfish.grizzly.monitoring.DefaultMonitoringConfig;
+import org.glassfish.grizzly.monitoring.MonitoringUtils;
 
 /**
  * @author mazhen
  */
-public class VirtualThreadExecutorService extends AbstractExecutorService implements Thread.UncaughtExceptionHandler {
+public class VirtualThreadExecutorService extends AbstractExecutorService implements ThreadPoolInfo, Thread.UncaughtExceptionHandler {
 
     private static final Logger logger = Grizzly.logger(VirtualThreadExecutorService.class);
 
     private final ExecutorService internalExecutorService;
     private final Semaphore poolSemaphore;
     private final Semaphore queueSemaphore;
+    private final AtomicInteger threadsCount = new AtomicInteger();
+    private final AtomicInteger queueSize = new AtomicInteger();
+    private final ThreadPoolConfig originalConfig;
+
+    /**
+     * ThreadPool probes
+     */
+    protected final DefaultMonitoringConfig<ThreadPoolProbe> monitoringConfig = new DefaultMonitoringConfig<ThreadPoolProbe>(ThreadPoolProbe.class) {
+
+        @Override
+        public Object createManagementObject() {
+            return createJmxManagementObject();
+        }
+
+    };
 
     public static VirtualThreadExecutorService createInstance() {
         return createInstance(ThreadPoolConfig.defaultConfig().setMaxPoolSize(-1).setPoolName("Grizzly-virt-"));
@@ -35,11 +69,16 @@ public class VirtualThreadExecutorService extends AbstractExecutorService implem
         return new VirtualThreadExecutorService(cfg);
     }
 
-    protected VirtualThreadExecutorService(ThreadPoolConfig cfg) {
-        internalExecutorService = Executors.newThreadPerTaskExecutor(getThreadFactory(cfg));
+    protected VirtualThreadExecutorService(ThreadPoolConfig config) {
+        originalConfig = config;
+        if (config.getInitialMonitoringConfig().hasProbes()) {
+            monitoringConfig.addProbes(config.getInitialMonitoringConfig().getProbes());
+        }
 
-        int poolSizeLimit = cfg.getMaxPoolSize() > 0 ? cfg.getMaxPoolSize() : Integer.MAX_VALUE;
-        int queueLimit = cfg.getQueueLimit() >= 0 ? cfg.getQueueLimit() : Integer.MAX_VALUE;
+        internalExecutorService = Executors.newThreadPerTaskExecutor(getThreadFactory(config));
+
+        int poolSizeLimit = config.getMaxPoolSize() > 0 ? config.getMaxPoolSize() : Integer.MAX_VALUE;
+        int queueLimit = config.getQueueLimit() >= 0 ? config.getQueueLimit() : Integer.MAX_VALUE;
         // Check for integer overflow
         long totalLimit = (long) poolSizeLimit + (long) queueLimit;
         if (totalLimit > Integer.MAX_VALUE) {
@@ -74,11 +113,19 @@ public class VirtualThreadExecutorService extends AbstractExecutorService implem
     @Override
     public void shutdown() {
         internalExecutorService.shutdown();
+        ProbeNotifier.notifyThreadPoolStopped(this);
+
     }
 
     @Override
     public List<Runnable> shutdownNow() {
-        return internalExecutorService.shutdownNow();
+        final List<Runnable> tasks = internalExecutorService.shutdownNow();
+        for (Runnable cancelledTask : tasks) {
+            onTaskDequeued(cancelledTask);
+            onTaskCancelled(cancelledTask);
+        }
+        ProbeNotifier.notifyThreadPoolStopped(this);
+        return tasks;
     }
 
     @Override
@@ -97,29 +144,144 @@ public class VirtualThreadExecutorService extends AbstractExecutorService implem
     }
 
     @Override
-    public void execute(Runnable command) {
+    public void execute(Runnable task) {
         if (!queueSemaphore.tryAcquire()) {
             throw new RejectedExecutionException("Too Many Concurrent Requests");
         }
 
         internalExecutorService.execute(() -> {
+            final Thread currentThread = Thread.currentThread();
+            onWorkerStarted(currentThread);
+            threadsCount.incrementAndGet();
             try {
-                poolSemaphore.acquire();
+                onTaskQueued(task);
                 try {
-                    command.run();
+                    poolSemaphore.acquire();
+                } finally {
+                    onTaskDequeued(task);
+                }
+                if (poolSemaphore.availablePermits() == 0) {
+                    onMaxNumberOfThreadsReached();
+                }
+                try {
+                    task.run();
+                    onTaskCompletedEvent(task);
                 } finally {
                     poolSemaphore.release();
                 }
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                currentThread.interrupt();
+                onTaskCancelled(task);
             } finally {
                 queueSemaphore.release();
+                threadsCount.decrementAndGet();
+                onWorkerExit(currentThread);
             }
         });
+    }
+
+    private void beforeExecute(final AbstractThreadPool.Worker worker, final Thread t, final Runnable r) {
+        final ClassLoader initial = getConfig().getInitialClassLoader();
+        if (initial != null) {
+            t.setContextClassLoader(initial);
+        }
     }
 
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         logger.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_THREADPOOL_UNCAUGHT_EXCEPTION(thread), throwable);
     }
+
+    @Override
+    public int getSize() {
+        return threadsCount.get();
+    }
+
+    @Override
+    public ThreadPoolConfig getConfig() {
+        return originalConfig;
+    }
+
+    @Override
+    public DefaultMonitoringConfig<ThreadPoolProbe> getMonitoringConfig() {
+        return monitoringConfig;
+    }
+
+    @Override
+    public int getQueueSize() {
+        return 0;
+    }
+
+    Object createJmxManagementObject() {
+        return MonitoringUtils.loadJmxObject("org.glassfish.grizzly.threadpool.jmx.ThreadPool", this, ThreadPoolInfo.class);
+    }
+
+    /**
+     * <p>
+     * This method will be invoked when a the specified {@link Runnable} has completed execution.
+     * </p>
+     *
+     * @param task the unit of work that has completed processing
+     */
+    protected void onTaskCompletedEvent(Runnable task) {
+        ProbeNotifier.notifyTaskCompleted(this, task);
+    }
+
+    /**
+     * Method is called by {@link Worker}, when it's starting {@link Worker#run()} method execution, which means, that
+     * ThreadPool's thread is getting active and ready to process tasks. This method is called from {@link Worker}'s thread.
+     *
+     * @param worker
+     */
+    protected void onWorkerStarted(Thread thread) {
+        ProbeNotifier.notifyThreadAllocated(this, thread);
+    }
+
+    /**
+     * Method is called by {@link Worker}, when it's completing {@link Worker#run()} method execution, which in most cases
+     * means, that ThreadPool's thread will be released. This method is called from {@link Worker}'s thread.
+     *
+     * @param worker
+     */
+    protected void onWorkerExit(Thread thread) {
+        ProbeNotifier.notifyThreadReleased(this, thread);
+    }
+
+    /**
+     * Method is called by <tt>AbstractThreadPool</tt>, when maximum number of worker threads is reached and task will need
+     * to wait in task queue, until one of the threads will be able to process it.
+     */
+    protected void onMaxNumberOfThreadsReached() {
+        ProbeNotifier.notifyMaxNumberOfThreads(this, getConfig().getMaxPoolSize());
+    }
+
+    /**
+     * Method is called by a thread pool each time new task has been queued to a task queue.
+     *
+     * @param task
+     */
+    protected void onTaskQueued(Runnable task) {
+        queueSize.incrementAndGet();
+        ProbeNotifier.notifyTaskQueued(this, task);
+    }
+
+    /**
+     * Method is called by a thread pool each time a task has been dequeued from a task queue.
+     *
+     * @param task
+     */
+    protected void onTaskDequeued(Runnable task) {
+        queueSize.decrementAndGet();
+        ProbeNotifier.notifyTaskDequeued(this, task);
+    }
+
+    /**
+     * Method is called by a thread pool each time a dequeued task has been canceled instead of being processed.
+     *
+     * @param task
+     */
+    protected void onTaskCancelled(Runnable task) {
+        ProbeNotifier.notifyTaskCancelled(this, task);
+    }
+
 }

--- a/modules/grizzly/src/test/java/org/glassfish/grizzly/VirtualThreadExecutorServiceTest.java
+++ b/modules/grizzly/src/test/java/org/glassfish/grizzly/VirtualThreadExecutorServiceTest.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 package org.glassfish.grizzly;
 
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.glassfish.grizzly.threadpool.ThreadPoolInfo;
+import org.glassfish.grizzly.threadpool.ThreadPoolProbe;
 import org.glassfish.grizzly.threadpool.VirtualThreadExecutorService;
 import org.junit.Assert;
 
@@ -83,5 +100,64 @@ public class VirtualThreadExecutorServiceTest extends GrizzlyTestCase {
             r.execute(() -> cl.countDown());
         }
         assertTrue("latch timed out", cl.await(30, TimeUnit.SECONDS));
+    }
+
+    public void testProbeNotifications() throws Exception {
+        final CountDownLatch taskQueuedLatch = new CountDownLatch(1);
+        final CountDownLatch taskDequeuedLatch = new CountDownLatch(1);
+        final CountDownLatch taskCompletedLatch = new CountDownLatch(1);
+        final CountDownLatch threadAllocatedLatch = new CountDownLatch(1);
+        final CountDownLatch threadReleasedLatch = new CountDownLatch(1);
+
+        ThreadPoolProbe probe = new ThreadPoolProbe.Adapter() {
+            @Override
+            public void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task) {
+                taskQueuedLatch.countDown();
+            }
+
+            @Override
+            public void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task) {
+                taskDequeuedLatch.countDown();
+            }
+
+            @Override
+            public void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task) {
+                taskCompletedLatch.countDown();
+            }
+
+            @Override
+            public void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread) {
+                threadAllocatedLatch.countDown();
+            }
+
+            @Override
+            public void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread) {
+                threadReleasedLatch.countDown();
+            }
+        };
+
+        ThreadPoolConfig config = ThreadPoolConfig.defaultConfig();
+        config.getInitialMonitoringConfig().addProbes(probe);
+
+        VirtualThreadExecutorService executor = VirtualThreadExecutorService.createInstance(config);
+
+        CountDownLatch taskLatch = new CountDownLatch(1);
+        executor.execute(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            taskLatch.countDown();
+        });
+
+        assertTrue("Task should complete", taskLatch.await(5, TimeUnit.SECONDS));
+        assertTrue("Task queued probe should be called", taskQueuedLatch.await(1, TimeUnit.SECONDS));
+        assertTrue("Task dequeued probe should be called", taskDequeuedLatch.await(1, TimeUnit.SECONDS));
+        assertTrue("Task completed probe should be called", taskCompletedLatch.await(1, TimeUnit.SECONDS));
+        assertTrue("Thread allocated probe should be called", threadAllocatedLatch.await(1, TimeUnit.SECONDS));
+        assertTrue("Thread released probe should be called", threadReleasedLatch.await(1, TimeUnit.SECONDS));
+
+        executor.shutdown();
     }
 }


### PR DESCRIPTION
Extracted thread pool info to a common interface that can be provided by both platform and virtual thread executors and added calls to probes in the VT executor.