### PR TITLE
POM Cleanup and removed unused imports in java sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,4 @@ nbactions.xml
 .classpath
 .project
 .settings/
-modules/bundles/comet/src
-modules/bundles/core/src
-modules/bundles/http/src
-modules/bundles/http-all/src
-modules/bundles/http-servlet/src
-modules/bundles/websockets/src
+

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2024 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -211,11 +211,8 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <requireJavaVersion>
-                                    <version>[11,)</version>
-                                </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.5.4</version>
+                                    <version>3.8.9</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -169,37 +169,6 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
-                    <configuration>
-                        <additionalOptions>
-                            <additionalOption>-Xdoclint:none</additionalOption>
-                        </additionalOptions>
-                    </configuration>
-                </plugin>
-                <plugin><!--
-                        Can not use 3.3.0, which triggers:
-
-                        Presumably you have configured maven-source-plugn to execute twice times in your build. You have to configure a classifier for at least on of them.
-
-                    -->
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -36,6 +36,8 @@
     <name>grizzly-bom</name>
     <description>Grizzly Bill of Materials (BOM)</description>
 
+    <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -33,7 +33,7 @@
     <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>grizzly-bom</name>
+    <name>Grizzly BOM</name>
     <description>Grizzly Bill of Materials (BOM)</description>
 
     <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
 
-    <name>connection-pool</name>
+    <name>Grizzly Extras: HTTP Endpoint Connection Pool</name>
 
     <dependencies>
         <dependency>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>connection-pool</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Extras: HTTP Endpoint Connection Pool</name>
 
@@ -41,30 +40,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.connectionpool.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -82,7 +70,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-server-jaxws</name>
+    <name>Grizzly Extras: Metro Web Services Integration</name>
 
     <dependencies>
         <dependency>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-server-jaxws</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Extras: Metro Web Services Integration</name>
 
@@ -41,7 +40,7 @@
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -52,39 +51,31 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-osgi</artifactId>
-            <version>4.0.5</version>
+            <version>4.0.6</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-osgi</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.4</version>
             <type>jar</type>
         </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.jaxws.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -102,7 +93,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/extras/http-server-jaxws/src/test/java/org/glassfish/grizzly/jaxws/JaxwsTest.java
+++ b/extras/http-server-jaxws/src/test/java/org/glassfish/grizzly/jaxws/JaxwsTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +19,7 @@ package org.glassfish.grizzly.jaxws;
 
 import java.io.IOException;
 import java.util.Random;
+
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpHandlerRegistration;
 import org.glassfish.grizzly.http.server.HttpServer;
@@ -25,45 +27,46 @@ import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.StaticHttpHandler;
 import org.glassfish.grizzly.jaxws.addclient.AddServiceService;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Basic Grizzly JAX-WS {@link HttpHandler} test.
- * 
+ *
  * @author Alexey Stashok
  */
 public class JaxwsTest {
     private static final int PORT = 19881;
-    
+
     private HttpServer httpServer;
-    
+
     @Test
     public void testSync() throws Exception {
         startServer(new JaxwsHandler(new AddService(), false));
-        
+
         try {
             test(10);
         } finally {
             stopServer();
         }
     }
-    
+
     @Test
     public void testAsync() throws Exception {
         startServer(new JaxwsHandler(new AddService(), true));
-        
+
         try {
             test(10);
         } finally {
             stopServer();
         }
-        
+
     }
-    
+
     private void startServer(HttpHandler httpHandler) throws IOException {
         httpServer = new HttpServer();
         NetworkListener networkListener = new NetworkListener("jaxws-listener", "0.0.0.0", PORT);
-        
+
         httpServer.getServerConfiguration().addHttpHandler(new StaticHttpHandler(), "/add"); // make sure JAX-WS Handler is not default
         httpServer.getServerConfiguration().addHttpHandler(httpHandler,
                 HttpHandlerRegistration.bulder()
@@ -71,24 +74,24 @@ public class JaxwsTest {
                     .urlPattern("/")
                     .build());
         httpServer.addListener(networkListener);
-        
-        httpServer.start();        
+
+        httpServer.start();
     }
-    
+
     private void stopServer() {
         httpServer.shutdownNow();
     }
 
     private void test(int n) {
         final Random random = new Random();
-        
+
         AddServiceService service = new AddServiceService();
         org.glassfish.grizzly.jaxws.addclient.AddService port = service.getAddServicePort();
         for (int i=0; i<n; i++) {
             final int value1 = random.nextInt(1000);
             final int value2 = random.nextInt(1000);
             final int result = port.add(value1, value2);
-            
+
             assertEquals(value1 + value2, result);
         }
     }

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-server-multipart</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Extras: MIME Multipart Support</name>
 
@@ -37,40 +36,27 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.multipart.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -87,14 +73,7 @@
 
     <reporting>
         <plugins>
-            <!--
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-            </plugin>
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-server-multipart</name>
+    <name>Grizzly Extras: MIME Multipart Support</name>
 
     <dependencies>
         <dependency>

--- a/extras/http-server-multipart/src/main/java/module-info.java
+++ b/extras/http-server-multipart/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * @author David Matejcek
+ */
+module org.glassfish.grizzly.http.server.multipart {
+
+    requires java.logging;
+
+    requires org.glassfish.grizzly;
+    requires org.glassfish.grizzly.http;
+    requires org.glassfish.grizzly.http.server;
+
+    exports org.glassfish.grizzly.http.multipart;
+}

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-servlet-extras</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Extras: Servlet</name>
 
@@ -37,12 +36,10 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server-multipart</artifactId>
-            <version>${project.version}</version>
         </dependency>
          <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -52,30 +49,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.servlet.extras.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -92,14 +78,7 @@
 
     <reporting>
         <plugins>
-            <!--
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-            </plugin>
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -47,6 +47,7 @@
          <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-servlet-extras</name>
+    <name>Grizzly Extras: Servlet</name>
 
     <dependencies>
         <dependency>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
 
-    <name>grizzly-extras</name>
+    <name>Grizzly Extras: Aggregator POM</name>
 
     <modules>
         <module>http-server-multipart</module>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>tls-sni</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Extras: TLS Server Name Indication (SNI) Implementation</name>
 
@@ -41,30 +40,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.sni.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -82,7 +70,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
 
-    <name>tls-sni</name>
+    <name>Grizzly Extras: TLS Server Name Indication (SNI) Implementation</name>
 
     <dependencies>
         <dependency>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-comet-server</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly Server with Comet Support</name>
     <!-- See https://en.wikipedia.org/wiki/Comet_(programming) -->
@@ -55,111 +54,77 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-
-                            <!--
-
-                                As this is a bundle we are excluding
-                                module-info.java files when unpacking the
-                                project dependencies.
-
-                                -->
-                            <excludes>module-info.java</excludes>
-                            <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <includeScope>compile</includeScope>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/grizzly</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;-split-package:=merge-first;version=${project.version}
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 </project>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,17 @@
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-comet-server</name>
+    <name>Bundle: Grizzly Server with Comet Support</name>
+    <!-- See https://en.wikipedia.org/wiki/Comet_(programming) -->
+    <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
+    <description>
+ Comet is a web application model in which a long-held HTTPS request
+ allows a web server to push data to a browser, without the browser
+ explicitly requesting it.
+ Comet is known by several other names, including Ajax Push,
+ Reverse Ajax, Two-way-web, HTTP Streaming, and HTTP server
+ push among others.
+    </description>
 
     <dependencies>
         <dependency>
@@ -59,7 +69,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
@@ -73,13 +83,13 @@
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            
-                            <!-- 
 
-                                As this is a bundle we are excluding 
-                                module-info.java files when unpacking the 
+                            <!--
+
+                                As this is a bundle we are excluding
+                                module-info.java files when unpacking the
                                 project dependencies.
-                                 
+
                                 -->
                             <excludes>module-info.java</excludes>
                             <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
@@ -93,7 +103,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -120,7 +130,7 @@
                     </execution>
                 </executions>
             </plugin>
-           
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -131,7 +141,7 @@
                     </execution>
                 </executions>
             </plugin>
-          
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
@@ -149,7 +159,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
     </build>
 </project>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-core</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly Core</name>
     <description>Repackaged framework and portunif jar files</description>
@@ -46,118 +45,77 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-            
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <!-- 
-
-                                As this is a bundle we are excluding 
-                                module-info.java files when unpacking the 
-                                project dependencies.
-                                 
-                                -->
-                            <excludes>module-info.java</excludes>
-                            <excludeArtifactIds>junit,hamcrest-core</excludeArtifactIds>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <includeScope>compile</includeScope>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/grizzly</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;-split-package:=merge-first;version=${project.version}
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-            
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
             </plugin>
-            
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>
             </plugin>
-            
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            
         </plugins>
     </build>
 </project>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-core</name>
+    <name>Bundle: Grizzly Core</name>
+    <description>Repackaged framework and portunif jar files</description>
 
     <dependencies>
         <dependency>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-all</name>
+    <name>Bundle: Grizzly HTTP</name>
+    <description>Repackaged HTTP jar files</description>
 
     <dependencies>
         <dependency>
@@ -71,7 +72,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
@@ -97,7 +98,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -125,7 +126,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -136,7 +137,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
@@ -154,7 +155,7 @@
                     </execution>
                 </executions>
             </plugin>
-           
+
         </plugins>
     </build>
 </project>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-all</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly HTTP</name>
     <description>Repackaged HTTP jar files</description>
@@ -58,104 +57,79 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
-                            <excludes>module-info.java</excludes>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <includeScope>compile</includeScope>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/grizzly</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>**/*.dtd</include>
+                                        <include>**/*.xsd</include>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            *
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;-split-package:=merge-first;version=${project.version},
-                            jakarta.servlet.*;version=${servlet-version};-split-package:=merge-first
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 </project>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-servlet-server</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly HTTP Servlet Server</name>
     <description>Repackaged HTTP servlet server jar files</description>
@@ -47,107 +46,86 @@
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet-extras</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
              <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
-                            <excludes>module-info.java</excludes>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <excludeArtifactIds>junit,hamcrest-core</excludeArtifactIds>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/grizzly</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>**/*.dtd</include>
+                                        <include>**/*.xsd</include>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;version=${project.version};-split-package:=merge-first,
-                            jakarta.servlet.*;version=${servlet-version};-split-package:=merge-first
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 </project>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-http-servlet-server</name>
+    <name>Bundle: Grizzly HTTP Servlet Server</name>
+    <description>Repackaged HTTP servlet server jar files</description>
 
     <dependencies>
         <dependency>
@@ -63,7 +64,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
              <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
@@ -89,7 +90,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -117,7 +118,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -128,7 +129,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
@@ -146,7 +147,7 @@
                     </execution>
                 </executions>
             </plugin>
-           
+
         </plugins>
     </build>
 </project>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-http-server-core</name>
+    <name>Bundle: Grizzly Server Core</name>
+    <description>Repackaged Server jar files</description>
 
     <dependencies>
         <dependency>
@@ -76,7 +77,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
@@ -90,12 +91,12 @@
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <!-- 
+                            <!--
 
-                                As this is a bundle we are excluding 
-                                module-info.java files when unpacking the 
+                                As this is a bundle we are excluding
+                                module-info.java files when unpacking the
                                 project dependencies.
-                                 
+
                                 -->
                             <excludes>module-info.java</excludes>
                             <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
@@ -109,7 +110,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -137,7 +138,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -148,7 +149,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-server-core</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly Server Core</name>
     <description>Repackaged Server jar files</description>
@@ -63,107 +62,70 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <!--
-
-                                As this is a bundle we are excluding
-                                module-info.java files when unpacking the
-                                project dependencies.
-
-                                -->
-                            <excludes>module-info.java</excludes>
-                            <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <excludeArtifactIds>junit,hamcrest-core</excludeArtifactIds>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Import-Package>
-                            !android.os,
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;version=${project.version};-split-package:=merge-first,
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
+                        <!-- because of impl packages -->
+                        <Export-Package>*</Export-Package>
                     </instructions>
-                    <unpackBundle>true</unpackBundle>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -30,7 +31,7 @@
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
 
-    <name>grizzly-bundles</name>
+    <name>Bundle: Aggregator POM</name>
 
     <modules>
         <module>core</module>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
 
-    <name>grizzly-websockets-server</name>
+    <name>Bundle: Grizzly WebSockets Server</name>
+    <description>Repackaged WebSockets server jar files</description>
 
     <dependencies>
         <dependency>
@@ -69,7 +70,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>
@@ -95,7 +96,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -122,7 +123,7 @@
                     </execution>
                 </executions>
             </plugin>
-           
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -133,7 +134,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
@@ -151,7 +152,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
     </build>
 </project>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-websockets-server</artifactId>
-    <packaging>jar</packaging>
 
     <name>Bundle: Grizzly WebSockets Server</name>
     <description>Repackaged WebSockets server jar files</description>
@@ -56,103 +55,77 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
-                <configuration>
-                    <filesets>
-                        <!-- Make sure we remove the fake source directory. -->
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>src-dependencies</id>
+                        <id>unpack-sources-from-dependencies</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <classifier>sources</classifier>
-                            <excludeArtifactIds>junit, hamcrest-core</excludeArtifactIds>
-                            <excludes>module-info.java</excludes>
-                            <!-- fudge an actual source hierarchy so that the source
-                                 plugin can actually do something useful.  Otherwise,
-                                 you'll end up with an empty source jar -->
-                            <outputDirectory>${basedir}/src/main/java</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
+                            <excludes>module-info.java,META-INF/**</excludes>
+                            <excludeArtifactIds>junit,hamcrest-core</excludeArtifactIds>
+                            <outputDirectory>${project.build.directory}/generated-sources/grizzly</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source-directory</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>${project.build.directory}/generated-sources/grizzly</sources>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/grizzly</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;-split-package:=merge-first;version=${project.version}
-                        </Export-Package>
-                        <Embed-Dependency>org.glassfish.grizzly;scope=runtime
-                        </Embed-Dependency>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>osgi-bundle</id>
-                        <phase>package</phase>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>bundle</goal>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>fudge-source</id>
+                        <id>package-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="src" includeemptydirs="true" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 </project>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,17 @@
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-comet</name>
+    <name>Grizzly Comet Support</name>
+    <!-- See https://en.wikipedia.org/wiki/Comet_(programming) -->
+    <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
+    <description>
+ Comet is a web application model in which a long-held HTTPS request
+ allows a web server to push data to a browser, without the browser
+ explicitly requesting it.
+ Comet is known by several other names, including Ajax Push,
+ Reverse Ajax, Two-way-web, HTTP Streaming, and HTTP server
+ push among others.
+    </description>
 
     <dependencies>
         <dependency>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-comet</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Comet Support</name>
     <!-- See https://en.wikipedia.org/wiki/Comet_(programming) -->
@@ -47,19 +46,10 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
-            <version>${project.version}</version>
         </dependency>
-<!--        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-framework</artifactId>
-            <classifier>tests</classifier>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>-->
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -69,23 +59,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.comet.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -97,52 +83,12 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-<!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <check>
-                        <branchRate>85</branchRate>
-                        <lineRate>85</lineRate>
-                        <haltOnFailure>true</haltOnFailure>
-                        <totalBranchRate>85</totalBranchRate>
-                        <totalLineRate>85</totalLineRate>
-                        <packageLineRate>85</packageLineRate>
-                        <packageBranchRate>85</packageBranchRate>
-                    </check>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>clean</goal>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
--->
         </plugins>
     </build>
 
     <reporting>
         <plugins>
-            <!--
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-            </plugin>
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -29,12 +29,10 @@
     </parent>
 
     <artifactId>grizzly-framework</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Framework</name>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -54,28 +52,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            !android.os,
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-framework</name>
+    <name>Grizzly Framework</name>
 
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,12 @@
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-ajp</name>
+    <name>Grizzly HTTP AJP Bridge</name>
+    <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
+    <description>enables Grizzly-based servers to communicate with web servers
+ (like Apache HTTPD) using the AJP protocol, which is commonly used for
+ integrating Java application servers with front-end web servers for load
+ balancing and proxying.</description>
 
     <dependencies>
         <dependency>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -29,11 +29,10 @@
     </parent>
 
     <artifactId>grizzly-http-ajp</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly HTTP AJP Bridge</name>
     <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
-    <description>enables Grizzly-based servers to communicate with web servers
+    <description>Enables Grizzly-based servers to communicate with web servers
  (like Apache HTTPD) using the AJP protocol, which is commonly used for
  integrating Java application servers with front-end web servers for load
  balancing and proxying.</description>
@@ -42,7 +41,6 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -66,28 +64,17 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.ajp.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -32,7 +32,6 @@
     <packaging>bundle</packaging>
 
     <name>grizzly-http-ajp</name>
-    <url>https://projects.eclipse.org/projects/ee4j.glassfish</url>
 
     <dependencies>
         <dependency>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -46,8 +46,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>2.0.2-beta</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.21.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2025 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-server</name>
+    <name>Grizzly HTTP Server</name>
 
     <dependencies>
         <dependency>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-server</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly HTTP Server</name>
 
@@ -47,13 +46,10 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.21.0</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -72,30 +68,25 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-reads org.glassfish.grizzly.http=ALL-UNNAMED
                     </argLine>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            !android.os,
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.server.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormat.java
@@ -19,7 +19,6 @@ package org.glassfish.grizzly.http.server.accesslog;
 
 import static java.util.logging.Level.WARNING;
 
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
+++ b/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/accesslog/ApacheLogFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, 2025 Contributors to the Eclipse Foundation.
+ * Copyright 2021, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,6 @@
 
 package org.glassfish.grizzly.http.server.accesslog;
 
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.glassfish.grizzly.http.Method.GET;
-import static org.glassfish.grizzly.http.Protocol.HTTP_1_1;
-import static org.junit.Assert.assertEquals;
-
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Locale;
@@ -39,6 +31,14 @@ import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.glassfish.grizzly.http.Method.GET;
+import static org.glassfish.grizzly.http.Protocol.HTTP_1_1;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test for {@link ApacheLogFormat}

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -34,7 +34,7 @@
     <name>grizzly-http-servlet</name>
 
     <properties>
-        <jersey-version>3.1.3</jersey-version>
+        <jersey-version>4.0.0</jersey-version>
         <maven.compiler.argument>-Xlint:unchecked,-deprecation,fallthrough,finally,cast,dep-ann,empty,overrides</maven.compiler.argument>
     </properties>
 
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-servlet</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly HTTP Servlet Implementation</name>
 
@@ -69,33 +68,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            jakarta.servlet*;version="[6.0,7)",
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.servlet.*;version=${project.version}
-                        </Export-Package>
-                    </instructions>
-                    <unpackBundle>true</unpackBundle>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-servlet</name>
+    <name>Grizzly HTTP Servlet Implementation</name>
 
     <properties>
         <jersey-version>4.0.0</jersey-version>

--- a/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/ComplexHttpServerTest.java
+++ b/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/ComplexHttpServerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,19 +17,18 @@
 
 package org.glassfish.grizzly.servlet;
 
-import static java.util.logging.Level.INFO;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.security.SecureRandom;
 import java.util.logging.Logger;
 
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.http.server.HttpServer;
 
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import static java.util.logging.Level.INFO;
 
 /**
  * {@link HttpServer} tests.
@@ -40,7 +40,7 @@ public class ComplexHttpServerTest extends HttpServerAbstractTest {
 
     public static final int PORT = PORT();
     private static final Logger logger = Grizzly.logger(ComplexHttpServerTest.class);
-   
+
 
     /**
      * Want to test multiple servletMapping

--- a/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/HttpServerTest.java
+++ b/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/HttpServerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,31 +17,6 @@
 
 package org.glassfish.grizzly.servlet;
 
-import static java.util.logging.Level.INFO;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.ServerSocket;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.GeneralSecurityException;
-import java.util.logging.Logger;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSession;
-
-import org.glassfish.grizzly.Grizzly;
-import org.glassfish.grizzly.http.server.HttpHandler;
-import org.glassfish.grizzly.http.server.HttpServer;
-import org.glassfish.grizzly.http.server.Request;
-import org.glassfish.grizzly.http.server.Response;
-import org.glassfish.grizzly.ssl.SSLContextConfigurator;
-import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
-import org.junit.Ignore;
-
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -50,6 +26,18 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import org.glassfish.grizzly.Grizzly;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.junit.Test;
+
+import static java.util.logging.Level.INFO;
 
 /**
  * {@link HttpServer} tests.
@@ -62,9 +50,10 @@ public class HttpServerTest extends HttpServerAbstractTest {
     public static int PORT = PORT();
     private static Logger logger = Grizzly.logger(HttpServerTest.class);
 
+    @Test
     public void testAddHttpHandlerAfterStart() throws Exception {
         System.out.println("testAddHttpHandlerAfterStart");
-        
+
         try {
             int port = PORT + 1;
             startHttpServer(port);
@@ -81,9 +70,10 @@ public class HttpServerTest extends HttpServerAbstractTest {
         }
     }
 
+    @Test
     public void testMultipleAddHttpHandlerAfterStart() throws Exception {
         System.out.println("testMultipleAddHttpHandlerAfterStart");
-        
+
         try {
             int port = PORT + 2;
             startHttpServer(port);
@@ -103,6 +93,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
         }
     }
 
+    @Test
     public void testOverlapingAddHttpHandlerAfterStart() throws Exception {
         System.out.println("testOverlapingAddHttpHandlerAfterStart");
         try {
@@ -133,6 +124,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
      *
      * @throws IOException Error.
      */
+    @Test
     public void testStartContract() throws IOException {
         System.out.println("testStartContract");
         // lock port
@@ -239,6 +231,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
      *
      * @throws IOException Couldn't start {@link HttpServer}.
      */
+    @Test
     public void testFilterLifecycle() throws IOException {
 
         int port = PORT + 8;
@@ -282,6 +275,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
         assertTrue(destroy[0]);
     }
 
+    @Test
     public void testFilterLifecycleByServletName() throws IOException {
 
         int port = PORT + 8;
@@ -329,6 +323,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
      *
      * @throws IOException Fail.
      */
+    @Test
     public void testAddHttpHandlerBeforeAndAfterStart() throws IOException {
         System.out.println("testAddHttpHandlerBeforeAndAfterStart");
         try {
@@ -360,6 +355,7 @@ public class HttpServerTest extends HttpServerAbstractTest {
         }
     }
 
+    @Test
     public void testMultipleAddHttpHandlerBeforeStartAndOneAfter() throws IOException {
         System.out.println("testMultipleAddHttpHandlerBeforeStartAndOneAfter");
         try {

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http</name>
+    <name>Grizzly HTTP Protocol Handler</name>
 
     <dependencies>
         <dependency>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly HTTP Protocol Handler</name>
 
@@ -60,27 +59,17 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -29,12 +29,7 @@
     </parent>
 
     <artifactId>grizzly-http2</artifactId>
-
     <name>Grizzly HTTP/2 Protocol Handler</name>
-
-    <properties>
-        <bootClasspath></bootClasspath>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -58,61 +53,23 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
                         <phase>process-classes</phase>
                         <goals>
-                            <!--suppress MavenModelInspection -->
                             <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly.http.server.*;version="[2.3,${project.version}]";resolution:=optional,
-                            org.glassfish.grizzly.*;version="[2.3,${project.version}]",
-                            *
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http2.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.glassfish.hk2</groupId>
-                <artifactId>osgiversion-maven-plugin</artifactId>
-                <version>3.0.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                    <argLine>-XX:+HeapDumpOnOutOfMemoryError ${bootClasspath}</argLine>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -120,7 +77,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <linkXRef>false</linkXRef>

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2025 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@
 
     <artifactId>grizzly-http2</artifactId>
 
-    <name>grizzly-http2</name>
+    <name>Grizzly HTTP/2 Protocol Handler</name>
 
     <properties>
         <bootClasspath></bootClasspath>
@@ -44,8 +44,8 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <!-- These dependencies aren't needed in the client case. Only if the project is using the Http2Addon or the
-                GlassFish integration code -->
+            <!-- These dependencies aren't needed in the client case.
+                Only if the project is using the Http2Addon or the GlassFish integration code -->
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnServerNegotiatorImpl.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/AlpnServerNegotiatorImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,16 +31,14 @@ final class AlpnServerNegotiatorImpl extends AlpnNegotiatorBase implements AlpnS
     private final static Logger LOGGER = Grizzly.logger(AlpnServerNegotiatorImpl.class);
 
     private final Http2BaseFilter filter;
-    // ---------------------------------------------------- Constructors
 
     public AlpnServerNegotiatorImpl(final Http2ServerFilter http2HandlerFilter) {
         this.filter = http2HandlerFilter;
     }
 
-    // ------------------------------- Methods from ServerSideNegotiator
     @Override
     public String selectProtocol(SSLEngine sslEngine, String[] clientProtocols) {
-        final Connection connection = AlpnSupport.getConnection(sslEngine);
+        final Connection<?> connection = AlpnSupport.getConnection(sslEngine);
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, "Alpn selectProtocol. Connection={0} sslEngine={1} clientProtocols={2}",
                     new Object[] { connection, sslEngine, Arrays.toString(clientProtocols) });
@@ -62,7 +61,7 @@ final class AlpnServerNegotiatorImpl extends AlpnNegotiatorBase implements AlpnS
         return null;
     }
 
-    private void configureHttp2(final Connection connection, final String supportedProtocol) {
+    private void configureHttp2(final Connection<?> connection, final String supportedProtocol) {
         if (HTTP2.equals(supportedProtocol)) {
             // If HTTP2 is supported - initialize HTTP2 connection
             // Create HTTP2 connection and bind it to the Grizzly connection
@@ -78,5 +77,4 @@ final class AlpnServerNegotiatorImpl extends AlpnNegotiatorBase implements AlpnS
 //            http2Session.sendPreface();
         }
     }
-
-} // END ProtocolNegotiator
+}

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2AddOn.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2AddOn.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -104,7 +105,8 @@ public class Http2AddOn implements AddOn {
             return;
         }
         final SSLBaseFilter sslFilter = (SSLBaseFilter) builder.get(idx);
-        AlpnSupport.getInstance().configure(sslFilter);
-        AlpnSupport.getInstance().setServerSideNegotiator(transport, new AlpnServerNegotiatorImpl(http2Filter));
+        AlpnSupport alpnSupport = AlpnSupport.getInstance();
+        alpnSupport.configure(sslFilter);
+        alpnSupport.setServerSideNegotiator(transport, new AlpnServerNegotiatorImpl(http2Filter));
     }
 }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
@@ -17,11 +18,6 @@
 
 package org.glassfish.grizzly.http2;
 
-import static org.glassfish.grizzly.http2.Http2BaseFilter.PRI_PAYLOAD;
-import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_INITIAL_WINDOW_SIZE;
-import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_MAX_CONCURRENT_STREAMS;
-import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_MAX_HEADER_LIST_SIZE;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,7 +26,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -78,6 +73,11 @@ import org.glassfish.grizzly.memory.MemoryManager;
 import org.glassfish.grizzly.ssl.SSLBaseFilter;
 import org.glassfish.grizzly.utils.Futures;
 import org.glassfish.grizzly.utils.Holder;
+
+import static org.glassfish.grizzly.http2.Http2BaseFilter.PRI_PAYLOAD;
+import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_INITIAL_WINDOW_SIZE;
+import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_MAX_CONCURRENT_STREAMS;
+import static org.glassfish.grizzly.http2.frames.SettingsFrame.SETTINGS_MAX_HEADER_LIST_SIZE;
 
 /**
  * The HTTP2 session abstraction.
@@ -461,7 +461,7 @@ public class Http2Session {
 
     /**
      * Sets the default maximum number of concurrent streams allowed for this session by our side.
-     * 
+     *
      * @param localMaxConcurrentStreams max number of streams locally allowed
      */
     public void setLocalMaxConcurrentStreams(int localMaxConcurrentStreams) {
@@ -948,7 +948,7 @@ public class Http2Session {
     /**
      * Method is not thread-safe, it is expected that it will be called within {@link #getNewClientStreamLock()} lock scope.
      * The caller code is responsible for obtaining and releasing the mentioned {@link #getNewClientStreamLock()} lock.
-     * 
+     *
      * @param request the request that initiated the stream
      * @param streamId the ID of this new stream
      * @param parentStreamId the parent stream
@@ -1030,7 +1030,7 @@ public class Http2Session {
     /**
      * Initializes HTTP2 communication (if not initialized before) by forming HTTP2 connection and stream
      * {@link FilterChain}s.
-     * 
+     *
      * @param context the current {@link FilterChainContext}
      * @param isUpStream flag denoting the direction of the chain
      */

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-framework-monitoring</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Monitoring of Grizzly Framework</name>
 
@@ -65,30 +64,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.memory.jmx.*;version=${project.version},
-                            org.glassfish.grizzly.monitoring.jmx.*;version=${project.version},
-                            org.glassfish.grizzly.nio.transport.jmx.*;version=${project.version},
-                            org.glassfish.grizzly.threadpool.jmx.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-framework-monitoring</name>
+    <name>Monitoring of Grizzly Framework</name>
 
     <dependencies>
         <dependency>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-server-monitoring</name>
+    <name>Monitoring of Grizzly HTTP Server</name>
 
     <dependencies>
         <dependency>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-server-monitoring</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Monitoring of Grizzly HTTP Server</name>
 
@@ -45,7 +44,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -65,28 +63,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.server.filecache.jmx.*;version=${project.version},
-                            org.glassfish.grizzly.http.server.jmx.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,7 @@
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-monitoring</name>
+    <name>Monitoring of Grizzly HTTP Protocol Handler</name>
 
     <dependencies>
         <dependency>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-http-monitoring</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Monitoring of Grizzly HTTP Protocol Handler</name>
 
@@ -45,7 +44,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -65,34 +63,37 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.http.jmx.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
                         <goals>
-                            <goal>test-jar</goal>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.sun.istack</groupId>
+                <artifactId>maven-istack-commons-plugin</artifactId>
+                <version>2.11</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <resources>
+                                <directory>${basedir}/src/main/resources</directory>
+                                <includes>
+                                    <include>**/*.properties</include>
+                                </includes>
+                            </resources>
+                            <destDir>${project.build.directory}/generated-sources</destDir>
+                            <localizationUtilitiesPkgName>org.glassfish.grizzly.localization</localizationUtilitiesPkgName>
+                        </configuration>
+                        <goals>
+                            <goal>rs-gen</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -116,24 +117,11 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>maven-istack-commons-plugin</artifactId>
-                <version>2.11</version>
+                <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <resources>
-                                <directory>${basedir}/src/main/resources</directory>
-                                <includes>
-                                    <include>**/*.properties</include>
-                                </includes>
-                            </resources>
-                            <destDir>${project.build.directory}/generated-sources</destDir>
-                            <localizationUtilitiesPkgName>org.glassfish.grizzly.localization</localizationUtilitiesPkgName>
-                        </configuration>
                         <goals>
-                            <goal>rs-gen</goal>
+                            <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
 
-    <name>grizzly-monitoring</name>
+    <name>Monitoring of Grizzly: Aggregator POM</name>
 
     <modules>
         <module>grizzly</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -29,7 +29,7 @@
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
 
-    <name>grizzly-modules</name>
+    <name>Grizzly: Aggregator POM</name>
 
     <modules>
         <module>grizzly</module>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,12 @@
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-portunif</name>
+    <name>Grizzly Port Protocol Unificator</name>
+    <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
+    <description>It enables a single network port to handle multiple protocols
+ by detecting the protocol of incoming connections and dispatching them
+ to the appropriate handler.
+    </description>
 
     <dependencies>
         <dependency>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-portunif</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly Port Protocol Unificator</name>
     <!-- WARN: Do not add/remove spaces, the felix plugin keeps them in manifest! -->
@@ -42,12 +41,10 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -64,27 +61,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.portunif.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,7 +31,8 @@
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-websockets</name>
+    <name>Grizzly WebSockets Support</name>
+    <description>WebSocket is a protocol providing a bidirectional communication channel over a single TCP connection.</description>
 
     <dependencies>
         <dependency>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <artifactId>grizzly-websockets</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Grizzly WebSockets Support</name>
     <description>WebSocket is a protocol providing a bidirectional communication channel over a single TCP connection.</description>
@@ -62,7 +61,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <filtering>true</filtering>
@@ -81,28 +79,17 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.websockets.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -181,6 +182,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.1</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
@@ -191,6 +197,27 @@
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.4.0</version>
+                    <configuration>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.6.3</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <notimestamp>true</notimestamp>
+                        <splitindex>true</splitindex>
+                        <doctitle>${project.name} ${project.version}</doctitle>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -203,8 +230,9 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.9</version>
+                    <version>6.0.0</version>
                     <configuration>
+                        <niceManifest>true</niceManifest>
                         <instructions>
                             <_noimportjava>true</_noimportjava>
                             <_runee>JavaSE-${java.version}</_runee>
@@ -252,7 +280,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
@@ -266,14 +293,7 @@
 
             <!-- Configure the jar with the javadoc -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <doclint>none</doclint>
-                    <notimestamp>true</notimestamp>
-                    <splitindex>true</splitindex>
-                    <doctitle>${project.name} ${project.version}</doctitle>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
     <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>grizzly-project</name>
+    <name>Grizzly Parent POM</name>
     <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
     <organization>
-        <name>Eclipse.org - GlassFish Project</name>
+        <name>Eclipse Foundation - GlassFish Project</name>
         <url>https://glassfish.org</url>
     </organization>
     <licenses>
@@ -101,10 +101,10 @@
     </mailingLists>
 
     <modules>
-        <module>boms/bom/</module>
-        <module>modules/</module>
-        <module>samples/</module>
-        <module>extras/</module>
+        <module>boms/bom</module>
+        <module>modules</module>
+        <module>samples</module>
+        <module>extras</module>
     </modules>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <packaging>pom</packaging>
 
     <name>Grizzly Parent POM</name>
+    <description>${project.artifactId}</description>
     <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
     <organization>
         <name>Eclipse Foundation - GlassFish Project</name>
@@ -153,6 +154,12 @@
                 <version>${osgi.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.21.0</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -166,8 +173,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
-        <directory>target</directory>
         <finalName>${project.artifactId}-${project.version}</finalName>
         <resources>
             <resource>
@@ -219,6 +224,11 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.4</version>
+                    <configuration>
+                        <reuseForks>false</reuseForks>
+                        <useModulePath>false</useModulePath>
+                        <argLine>-XX:+HeapDumpOnOutOfMemoryError</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -234,16 +244,22 @@
                     <version>6.0.0</version>
                     <configuration>
                         <niceManifest>true</niceManifest>
+                        <url>${project.url}</url>
                         <instructions>
                             <_noimportjava>true</_noimportjava>
                             <_runee>JavaSE-${java.version}</_runee>
+                            <Import-Package>
+                                !android.os,
+                                *,
+                            </Import-Package>
+                            <!-- Grizzly exports even impl packages -->
+                            <Export-Package>*</Export-Package>
                         </instructions>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
-            <!-- Sets minimal Maven version to 3.8.9 -->
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
@@ -270,12 +286,10 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                            <mode>development</mode>
-                            <url>${project.url}</url>
-                            <implementation-version>${project.version}</implementation-version>
-                            <package>org.glassfish.grizzly</package>
-                        </manifestEntries>
+                        <manifest>
+                            <addClasspath>false</addClasspath>
+                        </manifest>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -292,7 +306,6 @@
                 </executions>
             </plugin>
 
-            <!-- Configure the jar with the javadoc -->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
                     <version>3.4.0</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
+                        <propertiesEncoding>ISO-8859-1</propertiesEncoding>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <packaging>pom</packaging>
 
     <name>grizzly-project</name>
-    <url>https://projects.eclipse.org/projects/ee4j.glassfish</url>
+    <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
     <organization>
         <name>Eclipse.org - GlassFish Project</name>
         <url>https://glassfish.org</url>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,13 +26,12 @@
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>connection-pool-samples</name>
+    <name>Samples: Grizzly HTTP Endpoint Connection Pool</name>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>connection-pool</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -61,7 +60,7 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly HTTP Endpoint Connection Pool</name>
 
@@ -36,30 +35,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly Framework</name>
 
@@ -36,7 +35,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -49,27 +47,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,13 +26,12 @@
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-framework-samples</name>
+    <name>Samples: Grizzly Framework</name>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -71,7 +70,7 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly HTTP AJP Bridge</name>
 
@@ -36,30 +35,19 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.ajp.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,13 +26,12 @@
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-ajp-samples</name>
+    <name>Samples: Grizzly HTTP AJP Bridge</name>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-ajp</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -61,7 +60,7 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,7 +26,7 @@
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-jaxws-samples</name>
+    <name>Samples: Grizzly Metro Integration</name>
 
     <dependencies>
         <dependency>
@@ -67,7 +67,7 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly Metro Integration</name>
 
@@ -46,27 +45,22 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.jaxws.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,7 +26,7 @@
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-multipart-samples</name>
+    <name>Samples: Grizzly HTTP Multipart</name>
 
     <dependencies>
         <dependency>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -32,7 +32,10 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server-multipart</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-framework</artifactId>
         </dependency>
     </dependencies>
 
@@ -60,17 +63,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.httpmultipart.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly HTTP Multipart</name>
 
@@ -53,16 +52,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/http-multipart-samples/src/main/java/module-info.java
+++ b/samples/http-multipart-samples/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * @author David Matejcek
+ */
+module org.glassfish.grizzly.samples.httpmultipart {
+
+    requires java.logging;
+
+    requires org.glassfish.grizzly;
+    requires org.glassfish.grizzly.http;
+    requires org.glassfish.grizzly.http.server.multipart;
+    requires org.glassfish.grizzly.http.server;
+
+    exports org.glassfish.grizzly.samples.httpmultipart;
+}

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly HTTP</name>
 
@@ -36,7 +35,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -49,27 +47,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.http.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,13 +26,12 @@
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-samples</name>
+    <name>Samples: Grizzly HTTP</name>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -26,13 +26,12 @@
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-http-server-samples</name>
+    <name>Samples: Grizzly HTTP Server</name>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly HTTP Server</name>
 
@@ -36,7 +35,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -49,27 +47,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.httpserver.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -25,7 +25,7 @@
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
 
-    <name>grizzly-samples</name>
+    <name>Samples: Aggregator POM</name>
 
     <modules>
         <module>framework-samples</module>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,7 +26,7 @@
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-portunif-samples</name>
+    <name>Samples: Grizzly PortUnif</name>
 
     <dependencies>
         <dependency>
@@ -78,7 +78,7 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly PortUnif</name>
 
@@ -57,27 +56,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.portunif.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -24,7 +24,6 @@
 
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Samples: Grizzly TLS SNI Implementation</name>
 
@@ -52,26 +51,17 @@
         </testResources>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.glassfish.grizzly*;version=${project.version},
-                            *,
-                        </Import-Package>
-                        <Export-Package>
-                            org.glassfish.grizzly.samples.sni.*;version=${project.version},
-                        </Export-Package>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021, 2023 Contributors to the Eclipse Foundation.
+    Copyright 2021, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,7 +26,7 @@
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
 
-    <name>grizzly-tls-sni-samples</name>
+    <name>Samples: Grizzly TLS SNI Implementation</name>
 
     <dependencies>
         <dependency>
@@ -40,7 +40,6 @@
     </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -53,7 +52,6 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>false</reuseForks>


### PR DESCRIPTION
* Unused imports were reported by Checkstyle in my Eclipse workspace
* Defining plugins in BOM was not much useful, rather confusing
* I added proper names to all POMs and also descriptions to some of them.
* Fixed version in OSGI headers - using `version=${project.version}` is toxic with snapshots (and dashes), while Felix plugin is smart enough to resolve it on its own.
* I switched from bundle artifact type to jar file generating manifest. It is more readable.
* The bundles subdirectory unpacked zips and jars to src directory, then deleted it after processing. Now uses target directory, which is a standard maven convention.
* Updated Metro dependencies (patch release), Mockito and Jersey
* Added module-info to http-server-multipart

### Effects

* Fixes #2273 
* Fixed lot of maven warnings
* Fixed some of Eclipse IDE warnings
* Fixed confusing header in manifests saying that all jars are BOM (using the only name set)

Tested also together with https://github.com/eclipse-ee4j/glassfish/pull/25859 and all projects in this context.