### PR TITLE
Fixed initialization of Async Servlet ReadListener/WriteListener callbacks

### DIFF
--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletInputStreamImpl.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletInputStreamImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -146,10 +147,6 @@ public class ServletInputStreamImpl extends ServletInputStream {
      */
     @Override
     public boolean isReady() {
-        if (!hasSetReadListener) {
-            throw new IllegalStateException(LogMessages.WARNING_GRIZZLY_HTTP_SERVLET_INPUTSTREAM_ISREADY_ERROR());
-        }
-
         if (!prevIsReady) {
             return false;
         }
@@ -187,6 +184,18 @@ public class ServletInputStreamImpl extends ServletInputStream {
         }
 
         readHandler = new ReadHandlerImpl(readListener);
+
+        // Initial installation of ReadListener that will be notified
+        if (!inputStream.isReady()) {
+            prevIsReady = false;
+        }
+        IS_READY_SCOPE.set(Boolean.TRUE);
+        try {
+            inputStream.notifyAvailable(readHandler);
+        } finally {
+            IS_READY_SCOPE.remove();
+        }
+
         hasSetReadListener = true;
     }
 

--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletOutputStreamImpl.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletOutputStreamImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -98,10 +99,6 @@ public class ServletOutputStreamImpl extends ServletOutputStream {
      */
     @Override
     public boolean isReady() {
-        if (!hasSetWriteListener) {
-            throw new IllegalStateException(LogMessages.WARNING_GRIZZLY_HTTP_SERVLET_OUTPUTSTREAM_ISREADY_ERROR());
-        }
-
         if (!prevIsReady) {
             return false;
         }
@@ -140,6 +137,18 @@ public class ServletOutputStreamImpl extends ServletOutputStream {
         }
 
         writeHandler = new WriteHandlerImpl(writeListener);
+
+        // Initial installation of WriteListener that will be notified
+        if (!outputStream.canWrite()) {
+            prevIsReady = false;
+        }
+        CAN_WRITE_SCOPE.set(Boolean.TRUE);
+        try {
+            outputStream.notifyCanWrite(writeHandler);
+        } finally {
+            CAN_WRITE_SCOPE.remove();
+        }
+
         hasSetWriteListener = true;
     }
 

--- a/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/async/AsyncInputOutputTest.java
+++ b/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/async/AsyncInputOutputTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.servlet.async;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.glassfish.grizzly.Grizzly;
+import org.glassfish.grizzly.servlet.HttpServerAbstractTest;
+import org.glassfish.grizzly.servlet.ServletRegistration;
+import org.glassfish.grizzly.servlet.WebappContext;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AsyncInputOutputTest extends HttpServerAbstractTest {
+    private static final Logger LOGGER = Grizzly.logger(AsyncInputOutputTest.class);
+    private static final int PORT = PORT();
+
+    public void testNonBlockingInputOutput() throws Exception {
+        try {
+            newHttpServer(PORT);
+
+            final WebappContext ctx = new WebappContext("Test", "/contextPath");
+            final ServletRegistration reg = ctx.addServlet("foobar", new HttpServlet() {
+
+                @Override
+                protected void doPost(HttpServletRequest req, HttpServletResponse res)
+                        throws ServletException, IOException {
+                    final AsyncContext asyncContext = req.startAsync();
+                    final ServletInputStream input = req.getInputStream();
+                    final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                    input.setReadListener(new ReadListener() {
+
+                        @Override
+                        public void onDataAvailable() throws IOException {
+                            final byte[] bytes = new byte[1024];
+                            int len;
+                            while (input.isReady() && (len = input.read(bytes)) != -1) {
+                                buffer.write(bytes, 0, len);
+                            }
+                        }
+
+                        @Override
+                        public void onAllDataRead() throws IOException {
+                            final HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
+                            response.setContentType("text/plain");
+                            final ServletOutputStream output = response.getOutputStream();
+                            final byte[] responseBytes = ("Received " + buffer.size() + " bytes").getBytes();
+                            output.setWriteListener(new WriteListener() {
+                                int offset = 0;
+
+                                @Override
+                                public void onWritePossible() throws IOException {
+                                    while (output.isReady() && offset < responseBytes.length) {
+                                        output.write(responseBytes[offset++]);
+                                    }
+                                    if (offset >= responseBytes.length) {
+                                        asyncContext.complete();
+                                    }
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {
+                                    LOGGER.log(Level.WARNING, "Unexpected error", t);
+                                    asyncContext.complete();
+                                }
+                            });
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            LOGGER.log(Level.WARNING, "Unexpected error", t);
+                            asyncContext.complete();
+                        }
+                    });
+                }
+            });
+            reg.addMapping("/servletPath/*");
+            ctx.deploy(httpServer);
+            httpServer.start();
+
+            final HttpURLConnection conn = createConnection("/contextPath/servletPath/pathInfo", PORT);
+            conn.setChunkedStreamingMode(5);
+            conn.setDoOutput(true);
+            conn.connect();
+
+            BufferedReader input = null;
+            BufferedWriter output = null;
+            boolean expected = false;
+            try {
+                output = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+                final String data1 = "Hello";
+                final String data2 = "World";
+                try {
+                    output.write(data1);
+                    output.flush();
+                    int sleepInSeconds = 3;
+                    LOGGER.info("Sleeping " + sleepInSeconds + " seconds");
+                    Thread.sleep(sleepInSeconds * 1000);
+
+                    output.write(data2);
+                    output.flush();
+                    output.close();
+                } catch (Exception ignore) {
+                }
+                input = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                String line;
+                while ((line = input.readLine()) != null) {
+                    expected = line.equals("Received " + (data1.length() + data2.length()) + " bytes");
+                    if (expected) {
+                        break;
+                    }
+                }
+                assertTrue(expected);
+            } finally {
+                try {
+                    if (input != null) {
+                        input.close();
+                    }
+                } catch (Exception ignore) {
+                }
+                try {
+                    if (output != null) {
+                        output.close();
+                    }
+                } catch (Exception ignore) {
+                }
+            }
+        } finally {
+            stopHttpServer();
+        }
+    }
+}

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/InputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/InputBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -817,7 +817,7 @@ public class InputBuffer {
         if (size <= 0) {
             throw new IllegalArgumentException("size should be positive integer");
         }
-        if (this.handler != null) {
+        if (this.handler != null && this.handler != handler) {
             throw new IllegalStateException("Illegal attempt to register a new handler before the existing handler has been notified");
         }
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -789,7 +789,7 @@ public class OutputBuffer {
     }
 
     public void notifyCanWrite(final WriteHandler handler) {
-        if (this.handler != null) {
+        if (this.handler != null && this.handler != handler) {
             throw new IllegalStateException("Illegal attempt to set a new handler before the existing handler has been notified.");
         }
 


### PR DESCRIPTION
- https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2281
- The behavior of Read/Write listener callbacks requiring explicit isReady() calls to ServletInputStream/ServletOutputStream to be registered has been modified to allow initial registration when registering the listener.
- According to the Servlet spec, isReady() in blocking mode should always be true, but the behavior of throwing an IllegalStateException has been modified.
- Related test cases have been added.