### PR TITLE
Adjusting the log level during the initial socket configuration

### DIFF
--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOConnectorHandler.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOConnectorHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -111,7 +112,7 @@ public class TCPNIOConnectorHandler extends AbstractSocketConnectorHandler {
                 try {
                     socket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
                 } catch (Throwable t) {
-                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort, socket), t);
                 }
             }
 

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/TCPNIOTransport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -712,14 +713,14 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                 try {
                     socket.setReuseAddress(reuseAddress);
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(reuseAddress), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(reuseAddress, socket), e);
                 }
                 if (tcpNioTransport.isReusePortAvailable()) {
                     final boolean reusePort = tcpNioTransport.isReusePort();
                     try {
                         socket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
                     } catch (Throwable t) {
-                        LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                        LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort, socket), t);
                     }
                 }
             } else { // ServerSocketChannel
@@ -731,14 +732,14 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                 try {
                     serverSocket.setReuseAddress(tcpNioTransport.isReuseAddress());
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(tcpNioTransport.isReuseAddress()), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(tcpNioTransport.isReuseAddress(), serverSocket), e);
                 }
                 if (tcpNioTransport.isReusePortAvailable()) {
                     final boolean reusePort = tcpNioTransport.isReusePort();
                     try {
                         serverSocket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
                     } catch (Throwable t) {
-                        LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                        LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort, serverSocket), t);
                     }
                 }
             }
@@ -758,28 +759,28 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                         socket.setSoLinger(true, linger);
                     }
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_LINGER_EXCEPTION(linger), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_LINGER_EXCEPTION(linger, socket), e);
                 }
 
                 final boolean keepAlive = tcpNioTransport.isKeepAlive();
                 try {
                     socket.setKeepAlive(keepAlive);
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_KEEPALIVE_EXCEPTION(keepAlive), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_KEEPALIVE_EXCEPTION(keepAlive, socket), e);
                 }
 
                 final boolean tcpNoDelay = tcpNioTransport.isTcpNoDelay();
                 try {
                     socket.setTcpNoDelay(tcpNoDelay);
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_TCPNODELAY_EXCEPTION(tcpNoDelay), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_TCPNODELAY_EXCEPTION(tcpNoDelay, socket), e);
                 }
 
                 final int clientSocketSoTimeout = tcpNioTransport.getClientSocketSoTimeout();
                 try {
                     socket.setSoTimeout(clientSocketSoTimeout);
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(tcpNioTransport.getClientSocketSoTimeout()), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(tcpNioTransport.getClientSocketSoTimeout(), socket), e);
                 }
             } else { // ServerSocketChannel
                 final ServerSocketChannel serverSocketChannel = (ServerSocketChannel) channel;
@@ -788,7 +789,7 @@ public final class TCPNIOTransport extends NIOTransport implements AsyncQueueEna
                 try {
                     serverSocket.setSoTimeout(tcpNioTransport.getServerSocketSoTimeout());
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(tcpNioTransport.getServerSocketSoTimeout()), e);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(tcpNioTransport.getServerSocketSoTimeout(), serverSocket), e);
                 }
             }
         }

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOConnectorHandler.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOConnectorHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -114,7 +115,7 @@ public class UDPNIOConnectorHandler extends AbstractSocketConnectorHandler {
                 try {
                     socket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
                 } catch (Throwable t) {
-                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort, socket), t);
                 }
             }
 

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/nio/transport/UDPNIOTransport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -664,14 +665,14 @@ public final class UDPNIOTransport extends NIOTransport implements FilterChainEn
             try {
                 datagramSocket.setReuseAddress(udpNioTransport.isReuseAddress());
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(udpNioTransport.isReuseAddress()), e);
+                LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEADDRESS_EXCEPTION(udpNioTransport.isReuseAddress(), datagramSocket), e);
             }
             if (udpNioTransport.isReusePortAvailable()) {
                 final boolean reusePort = udpNioTransport.isReusePort();
                 try {
                     datagramSocket.setOption(StandardSocketOptions.SO_REUSEPORT, reusePort);
                 } catch (Throwable t) {
-                    LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort), t);
+                    LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_REUSEPORT_EXCEPTION(reusePort, datagramSocket), t);
                 }
             }
         }
@@ -690,7 +691,7 @@ public final class UDPNIOTransport extends NIOTransport implements FilterChainEn
             try {
                 datagramSocket.setSoTimeout(soTimeout);
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, LogMessages.WARNING_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(soTimeout), e);
+                LOGGER.log(Level.FINE, LogMessages.FINE_GRIZZLY_SOCKET_TIMEOUT_EXCEPTION(soTimeout, datagramSocket), e);
             }
         }
     }

--- a/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
+++ b/modules/grizzly/src/main/resources/org/glassfish/grizzly/localization/log.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Contributors to the Eclipse Foundation.
+# Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
 # Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -21,14 +21,13 @@
 #info.grizzly.start=GRIZZLY0001: Starting Grizzly Framework {0} - {1}
 #info.grizzly.configuration=GRIZZLY0002: \n Grizzly running on {0}-{1} under JDK version: {2}-{3}\n\t Thread Pool: {4}\n\t Read Selector: {5}\n\t auto-configure: {6}\n\t Using Leader/follower IOStrategy: {7}\n\t Number of SelectorHandler: {8}\n\t SelectionKeyHandler: {9}\n\t Context Caching: {10}\n\t Maximum Accept Retry: {11}\n\t Handler Read/Write I/O Concurrently {12}\n\t ProtocolChainHandler: {13}
 
-warning.grizzly.socket.linger.exception=GRIZZLY0003: Can not set SO_LINGER to {0}
-warning.grizzly.socket.tcpnodelay.exception=GRIZZLY0004: Can not set TCP_NODELAY to {0}
-warning.grizzly.socket.keepalive.exception=GRIZZLY0005: Can not set SO_KEEPALIVE to {0}
-warning.grizzly.socket.reuseaddress.exception=GRIZZLY0006: Can not set SO_REUSEADDR to {0}
-warning.grizzly.socket.reuseport.exception=GRIZZLY0035: Can not set SO_REUSEPORT to {0}
-fine.grizzly.socket.reuseport.exception=GRIZZLY0036: Can not set SO_REUSEPORT to {0}
+fine.grizzly.socket.linger.exception=GRIZZLY0003: Can not set SO_LINGER to {0}({1})
+fine.grizzly.socket.tcpnodelay.exception=GRIZZLY0004: Can not set TCP_NODELAY to {0}({1})
+fine.grizzly.socket.keepalive.exception=GRIZZLY0005: Can not set SO_KEEPALIVE to {0}({1})
+fine.grizzly.socket.reuseaddress.exception=GRIZZLY0006: Can not set SO_REUSEADDR to {0}({1})
+fine.grizzly.socket.reuseport.exception=GRIZZLY0036: Can not set SO_REUSEPORT to {0}({1})
 info.grizzly.socket.reuseport.exception=GRIZZLY0037: SO_REUSEPORT not supported
-warning.grizzly.socket.timeout.exception=GRIZZLY0007: Can not set SO_TIMEOUT to {0}
+fine.grizzly.socket.timeout.exception=GRIZZLY0007: Can not set SO_TIMEOUT to {0}({1})
 
 warning.grizzly.tcpselector-handler.acceptchannel.exception=GRIZZLY0008: Exception accepting channel
 fine.grizzly.asyncqueue.error-nocallback.error=GRIZZLY0009: No callback available to be notified about AsyncQueue error: {0}


### PR DESCRIPTION
- https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2285
- Failure of the initial socket settings SO_LINGER, SO_KEEPALIVE, TCP_NODELAY, SO_TIMEOUT, and SO_REUSEPORT is mostly due to a failure in the configuration of an invalid connection, so the level is lowered to proceed while ignoring the error.
- When printing the log, the corresponding socket information is also added.
- https://github.com/eclipse-ee4j/glassfish/pull/25973#issuecomment-4218816287