### PR TITLE
Updated parent to 2.0.2, fixed bom

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.2</version>
         <relativePath />
     </parent>
 
@@ -37,39 +37,6 @@
     <description>Grizzly Bill of Materials (BOM)</description>
 
     <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
-
-    <!-- TODO: Can be removed after it would be removed from parent too -->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <name>Disabled Sonatype Nexus</name>
-            <url>http://localhost</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <name>Disabled Sonatype Nexus</name>
-            <url>http://localhost</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </distributionManagement>
-
-    <properties>
-        <!-- Do not autopublish by default -->
-        <release.autopublish>false</release.autopublish>
-        <!-- By default block until everything is really published -->
-        <release.waitUntil>published</release.waitUntil>
-    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -233,33 +200,17 @@
                     <warn>false</warn>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <configuration>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>injected-nexus-deploy</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.10.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <autoPublish>${release.autopublish}</autoPublish>
-                    <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
-                    <deploymentName>Eclipse Grizzly ${project.version}</deploymentName>
-                    <publishingServerId>central</publishingServerId>
-                    <waitUntil>${release.waitUntil}</waitUntil>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>oss-release</id>
+            <properties>
+                <release.projectName>Eclipse Grizzly</release.projectName>
+                <release.autoPublish>false</release.autoPublish>
+                <release.waitUntil>published</release.waitUntil>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -18,7 +18,7 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -35,8 +35,37 @@
 
     <name>Grizzly BOM</name>
     <description>Grizzly Bill of Materials (BOM)</description>
-
     <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
+
+    <organization>
+        <name>Eclipse Foundation - GlassFish Project</name>
+        <url>https://glassfish.org</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>EPL-2.0</name>
+            <url>http://www.eclipse.org/legal/epl-2.0</url>
+        </license>
+    </licenses>
+    <mailingLists>
+        <mailingList>
+            <name>Mailing list: glassfish-dev</name>
+            <archive>glassfish-dev@eclipse.org</archive>
+        </mailingList>
+    </mailingLists>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse-ee4j/grizzly/issues</url>
+    </issueManagement>
+
+    <scm child.scm.connection.inherit.append.path="false"
+     child.scm.developerConnection.inherit.append.path="false"
+     child.scm.url.inherit.append.path="false">
+        <connection>scm:git:https://github.com/eclipse-ee4j/glassfish-grizzly.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-grizzly.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/glassfish-grizzly</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,23 +29,10 @@
     </parent>
 
     <artifactId>grizzly-project</artifactId>
-    <!-- Version must be repeated so versions-maven-plugin:set works correctly -->
-    <version>5.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Grizzly Parent POM</name>
     <description>${project.artifactId}</description>
-    <url>https://eclipse-ee4j.github.io/glassfish-grizzly</url>
-    <organization>
-        <name>Eclipse Foundation - GlassFish Project</name>
-        <url>https://glassfish.org</url>
-    </organization>
-    <licenses>
-        <license>
-            <name>EPL-2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-        </license>
-    </licenses>
 
     <developers>
         <developer>
@@ -94,51 +81,12 @@
         </contributor>
     </contributors>
 
-    <mailingLists>
-        <mailingList>
-            <name>Mailing list: glassfish-dev</name>
-            <archive>glassfish-dev@eclipse.org</archive>
-        </mailingList>
-    </mailingLists>
-
     <modules>
         <module>boms/bom</module>
         <module>modules</module>
         <module>samples</module>
         <module>extras</module>
     </modules>
-
-    <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/glassfish-grizzly.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-grizzly.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/glassfish-grizzly</url>
-        <tag>HEAD</tag>
-    </scm>
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/eclipse-ee4j/grizzly/issues</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-            <releases>
-                <checksumPolicy>fail</checksumPolicy>
-            </releases>
-        </repository>
-        <repository>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>fail</checksumPolicy>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <properties>
         <java.version>21</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>boms/bom/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
* Fixes #2278
* Added Grizzly to ["healthy projects"](https://ci.eclipse.org/glassfish/view/Release/job/all-projects-release-healthy/build?delay=0sec)
* Tested release locally:
```
version=5.0.1; mvn release:prepare -DpushChanges=false -DdevelopmentVersion=5.0.2-SNAPSHOT -DreleaseVersion=${version} -Dtag=${version} -Dresume=false -Poss-release -Dgpg.skip=true -DskipTests -Pfastest
git reset --hard HEAD^^
git tag -d 5.0.1
rm release.properties pom.xml.releaseBackup */pom.xml.releaseBackup */*/pom.xml.releaseBackup */*/*/pom.xml.releaseBackup
```
(One commit back I tested it also without the fastest profile, which is my local profile skipping tests, checkstyle, spotbugs and pmd plugins if present)