### PR TITLE
Strict header name and value validation by default

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
- * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2010,2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -113,13 +113,13 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      * @see #setRemoveHandledContentEncodingHeaders
      */
     private boolean removeHandledContentEncodingHeaders = false;
-    
+
     public static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
-    
+
     public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
-    
+
     private final boolean strictHeaderNameValidation;
-    
+
     private final boolean strictHeaderValueValidation;
 
     /**
@@ -179,7 +179,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
 
     /**
      * Callback method, called when {@link HttpPacket} parsing has been completed.
-     * 
+     *
      * @param httpHeader {@link HttpHeader}, which represents parsed HTTP packet header
      * @param ctx processing context.
      *
@@ -205,7 +205,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      * Invoked when either the request line or status line has been parsed.
      *
      * </p>
-     * 
+     *
      * @param httpHeader {@link HttpHeader}, which represents HTTP packet header
      * @param ctx processing context.
      */
@@ -319,9 +319,9 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         this.chunkingEnabled = chunkingEnabled;
         final Properties properties = Objects.requireNonNullElse(props, System.getProperties());
         this.strictHeaderNameValidation =
-                Boolean.parseBoolean(properties.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, "false"));
+                Boolean.parseBoolean(properties.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, "true"));
         this.strictHeaderValueValidation =
-                Boolean.parseBoolean(properties.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, "false"));
+                Boolean.parseBoolean(properties.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, "true"));
         this.preserveHeaderCase = Boolean.parseBoolean(properties.getProperty(PRESERVE_HEADER_CASE, "false"));
         transferEncodings.addAll(new FixedLengthTransferEncoding(), new ChunkedTransferEncoding(maxHeadersSize, props));
     }

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
- * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2011,2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,9 +67,13 @@ import org.glassfish.grizzly.utils.Pair;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Assume;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_NAME_VALIDATION_RFC_9110;
+import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_VALUE_VALIDATION_RFC_9110;
 
 /**
  * Chunked Transfer-Encoding tests.
@@ -79,7 +83,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class ChunkedTransferEncodingTest {
     public static final int PORT = PORT();
-    
+
     static int PORT() {
         try {
             int port = 19007 + SecureRandom.getInstanceStrong().nextInt(1000);
@@ -100,15 +104,36 @@ public class ChunkedTransferEncodingTest {
 
     final BlockingQueue<Future<Boolean>> resultQueue = new LinkedTransferQueue<>();
 
+    private final TestUtils.SystemPropertyToggle strictHeaderNameValidation;
+    private final TestUtils.SystemPropertyToggle strictHeaderValueValidation;
+
     @Parameters
     public static Collection<Object[]> getMode() {
-        return asList(new Object[][]{{"\r\n", FALSE, FALSE}, {"\r\n", FALSE, TRUE}, {"\r\n", TRUE, FALSE},
-                                     {"\r\n", TRUE, TRUE}, {"\n", FALSE, FALSE}, {"\n", FALSE, TRUE},
-                                     {"\n", TRUE, FALSE}, {"\n", TRUE, TRUE}});
+        return asList(new Object[][]{{"\r\n", FALSE, FALSE, FALSE, FALSE},
+                                     {"\r\n", FALSE, FALSE, TRUE, TRUE},
+                                     {"\r\n", FALSE, TRUE, null, null},
+                                     {"\r\n", TRUE, FALSE, null, null},
+                                     {"\r\n", TRUE, TRUE, null, null},
+                                     {"\n", FALSE, FALSE, null, null},
+                                     {"\n", FALSE, TRUE, null, null},
+                                     {"\n", TRUE, FALSE, null, null},
+                                     {"\n", TRUE, TRUE, null, null}});
+    }
+
+    public ChunkedTransferEncodingTest(String eol, boolean isChunkWhenParsing, boolean isStrictChunkedTransferCodingLineTerminator,
+            Boolean isStrictHeaderNameValidationSet, Boolean isStrictHeaderValueValidationSet) {
+        this.eol = eol;
+        this.isChunkWhenParsing = isChunkWhenParsing;
+        this.isStrictChunkedTransferCodingLineTerminator = isStrictChunkedTransferCodingLineTerminator;
+        this.strictHeaderNameValidation = new TestUtils.SystemPropertyToggle(STRICT_HEADER_NAME_VALIDATION_RFC_9110, isStrictHeaderNameValidationSet, true);
+        this.strictHeaderValueValidation = new TestUtils.SystemPropertyToggle(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, isStrictHeaderValueValidationSet, true);
     }
 
     @Before
     public void before() throws Exception {
+        strictHeaderNameValidation.set();
+        strictHeaderValueValidation.set();
+
         Grizzly.setTrackingThreadCache(true);
 
         FilterChainBuilder filterChainBuilder = FilterChainBuilder.stateless();
@@ -150,6 +175,9 @@ public class ChunkedTransferEncodingTest {
 
     @After
     public void after() throws Exception {
+        strictHeaderNameValidation.unset();
+        strictHeaderValueValidation.unset();
+
         if (connection != null) {
             connection.closeSilently();
         }
@@ -160,12 +188,6 @@ public class ChunkedTransferEncodingTest {
             } catch (Exception ignored) {
             }
         }
-    }
-
-    public ChunkedTransferEncodingTest(String eol, boolean isChunkWhenParsing, boolean isStrictChunkedTransferCodingLineTerminator) {
-        this.eol = eol;
-        this.isChunkWhenParsing = isChunkWhenParsing;
-        this.isStrictChunkedTransferCodingLineTerminator = isStrictChunkedTransferCodingLineTerminator;
     }
 
     @Test
@@ -193,7 +215,27 @@ public class ChunkedTransferEncodingTest {
         doHttpRequestTest(packetsNum, true, headers);
 
         for (int i = 0; i < packetsNum; i++) {
-            Future<Boolean> result = resultQueue.poll(10, SECONDS);
+            Future<Boolean> result = resultQueue.poll(1000, SECONDS);
+            assertNotNull("Timeout for result#" + i, result);
+            assertTrue(result.get(10, SECONDS));
+        }
+    }
+
+    @Test
+    public void testCorruptedTrailerHeaders() throws Exception {
+        // the behavior is undefined if validation disabled
+        Assume.assumeTrue(strictHeaderValueValidation.isEnabled());
+
+        Map<String, Pair<String, String>> headers = new HashMap<>();
+        headers.put("Content", new Pair<>("hello", "hello"));
+        headers.put("a", new Pair<>(null, null));
+
+        final int packetsNum = 1;
+
+        doHttpRequestTest(packetsNum, true, headers);
+
+        for (int i = 0; i < packetsNum; i++) {
+            Future<Boolean> result = resultQueue.poll(1000, SECONDS);
             assertNotNull("Timeout for result#" + i, result);
             assertTrue(result.get(10, SECONDS));
         }
@@ -360,6 +402,10 @@ public class ChunkedTransferEncodingTest {
         assertFalse((Boolean) method.invoke(null, value1));
     }
 
+    /*
+     Format of trailerHeaders: Map<headerName, Pair<headerValueInInput, headerValueExpectedInOutput>>
+     headerValueInInput is null means no value - corrupted header, just name without the colon and value.
+    */
     @SuppressWarnings("unchecked")
     private void doHttpRequestTest(int packetsNum, boolean hasContent, Map<String, Pair<String, String>> trailerHeaders) throws Exception {
 
@@ -398,9 +444,11 @@ public class ChunkedTransferEncodingTest {
 
             for (Entry<String, Pair<String, String>> entry : trailerHeaders.entrySet()) {
                 final String value = entry.getValue().getFirst();
+                sb.append(entry.getKey());
                 if (value != null) {
-                    sb.append(entry.getKey()).append(": ").append(value).append("\r\n");
+                    sb.append(": ").append(value);
                 }
+                sb.append("\r\n");
             }
 
             sb.append(eol);

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
- * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2010,2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,6 +50,7 @@ import org.glassfish.grizzly.utils.ChunkingFilter;
 import org.glassfish.grizzly.utils.Pair;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,45 +75,29 @@ public class HttpRequestParseTest {
 
     public static final int PORT = 19000;
 
-    private final boolean isStrictHeaderNameValidationSet;
-    private final boolean isStrictHeaderValueValidationSet;
-    private final String isStrictHeaderNameValidationSetBefore;
-    private final String isStrictHeaderValueValidationSetBefore;
+    private final TestUtils.SystemPropertyToggle strictHeaderNameValidation;
+    private final TestUtils.SystemPropertyToggle strictHeaderValueValidation;
 
     @Parameterized.Parameters
     public static Collection<Object[]> getMode() {
-        return asList(new Object[][] { { FALSE, FALSE }, { FALSE, TRUE }, { TRUE, FALSE }, { TRUE, TRUE } });
+        return asList(new Object[][] { { null, null }, { FALSE, FALSE }, { FALSE, TRUE }, { TRUE, FALSE }, { TRUE, TRUE } });
+    }
+
+    public HttpRequestParseTest(Boolean isStrictHeaderNameValidationSet, Boolean isStrictHeaderValueValidationSet) {
+        this.strictHeaderNameValidation = new TestUtils.SystemPropertyToggle(STRICT_HEADER_NAME_VALIDATION_RFC_9110, isStrictHeaderNameValidationSet, true);
+        this.strictHeaderValueValidation = new TestUtils.SystemPropertyToggle(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, isStrictHeaderValueValidationSet, true);
     }
 
     @Before
     public void before() throws Exception {
-        if (isStrictHeaderNameValidationSet) {
-            System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
-        } else {
-            System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
-        }
-        if (isStrictHeaderValueValidationSet) {
-            System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.TRUE));
-        } else {
-            System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110, String.valueOf(Boolean.FALSE));
-        }
+        strictHeaderNameValidation.set();
+        strictHeaderValueValidation.set();
     }
 
     @After
     public void after() throws Exception {
-        System.setProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110,
-                           isStrictHeaderNameValidationSetBefore != null ? isStrictHeaderNameValidationSetBefore :
-                           String.valueOf(Boolean.FALSE));
-        System.setProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110,
-                           isStrictHeaderValueValidationSetBefore != null ? isStrictHeaderValueValidationSetBefore :
-                           String.valueOf(Boolean.FALSE));
-    }
-
-    public HttpRequestParseTest(boolean isStrictHeaderNameValidationSet, boolean isStrictHeaderValueValidationSet) {
-        this.isStrictHeaderNameValidationSet = isStrictHeaderNameValidationSet;
-        this.isStrictHeaderValueValidationSet = isStrictHeaderValueValidationSet;
-        this.isStrictHeaderNameValidationSetBefore = System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110);
-        this.isStrictHeaderValueValidationSetBefore = System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110);
+        strictHeaderNameValidation.unset();
+        strictHeaderValueValidation.unset();
     }
 
     @Test
@@ -156,9 +141,8 @@ public class HttpRequestParseTest {
 
     @Test
     public void testDisallowedCharactersForHeaderNames() {
-        if (!isStrictHeaderNameValidationSet) {
-            return;
-        }
+        Assume.assumeTrue(strictHeaderNameValidation.isEnabled());
+
         final StringBuilder sb = new StringBuilder("GET / HTTP/1.1\r\n");
         sb.append("Host: localhost\r\n");
         sb.append(new char[]{0x00, 0x01, 0x02, '\t', '\n', '\r', ' ', '\"', '(', ')', '/', ';', '<', '=', '>', '?', '@',
@@ -186,9 +170,8 @@ public class HttpRequestParseTest {
 
     @Test
     public void testDisallowedCharactersForHeaderContentValues() {
-        if (!isStrictHeaderValueValidationSet) {
-            return;
-        }
+        Assume.assumeTrue(strictHeaderValueValidation.isEnabled());
+
         final StringBuilder sb = new StringBuilder("GET / HTTP/1.1\r\n");
         sb.append("Host: localhost\r\n");
         sb.append("Some-Header: some-");
@@ -224,9 +207,8 @@ public class HttpRequestParseTest {
 
     @Test
     public void testIgnoredHeaders() throws Exception {
-        if (!isStrictHeaderNameValidationSet) {
-            return;
-        }
+        Assume.assumeTrue(strictHeaderNameValidation.isEnabled());
+
         final Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Ignore\r\nContent-length", new Pair<>("2345", "2345"));
@@ -238,10 +220,9 @@ public class HttpRequestParseTest {
 
     @Test
     public void testMultiLineHeaders() throws Exception {
-        if (isStrictHeaderValueValidationSet) {
             // Multiline headers should not be supported
-            return;
-        }
+        Assume.assumeFalse(strictHeaderValueValidation.isEnabled());
+
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<>("first\r\n          second\r\n       third", "first second third"));
@@ -251,10 +232,9 @@ public class HttpRequestParseTest {
 
     @Test
     public void testHeadersN() throws Exception {
-        if (isStrictHeaderValueValidationSet) {
             // Multiline headers should not be supported
-            return;
-        }
+        Assume.assumeFalse(strictHeaderValueValidation.isEnabled());
+
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<>("first\r\n          second\n       third", "first second third"));
@@ -454,6 +434,8 @@ public class HttpRequestParseTest {
             }
 
             transport.shutdownNow();
+            // wait until the port is unbound
+            Thread.sleep(10);
         }
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
+
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.SocketConnectorHandler;
@@ -58,6 +59,7 @@ import org.junit.runners.Parameterized;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_NAME_VALIDATION_RFC_9110;
 import static org.glassfish.grizzly.http.HttpCodecFilter.STRICT_HEADER_VALUE_VALIDATION_RFC_9110;
@@ -397,7 +399,8 @@ public class HttpRequestParseTest {
         transport.setProcessor(filterChainBuilder.build());
 
         try {
-            transport.bind(PORT);
+            // we retry because it may take a short while until the port is unbound after previous tests
+            TestUtils.retryUntilSuccess(() -> transport.bind(PORT), ofSeconds(10), ofSeconds(1));
             transport.start();
 
             FilterChainBuilder clientFilterChainBuilder = FilterChainBuilder.stateless().add(new TransportFilter());
@@ -434,8 +437,6 @@ public class HttpRequestParseTest {
             }
 
             transport.shutdownNow();
-            // wait until the port is unbound
-            Thread.sleep(10);
         }
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/TestUtils.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/TestUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.grizzly.http;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class TestUtils {
+    public static class SystemPropertyToggle {
+        private final String propertyName;
+        private final Boolean propertyEnabled;
+        private final boolean enabledByDefault;
+        private String previousValue;
+
+        public SystemPropertyToggle(String propertyName, Boolean propertyEnabled, boolean enabledByDefault) {
+            this.propertyName = propertyName;
+            this.propertyEnabled = propertyEnabled;
+            this.enabledByDefault = enabledByDefault;
+        }
+
+        public boolean isEnabled() {
+            return propertyEnabled != null
+                    ? propertyEnabled
+                    : enabledByDefault;
+        }
+
+        public void set() {
+            previousValue = System.getProperty(propertyName);
+            setOrUnsetProperty(propertyEnabled == null
+                    ? null
+                    : String.valueOf(propertyEnabled.booleanValue()));
+        }
+
+        public void unset() {
+            setOrUnsetProperty(previousValue);
+        }
+
+        private void setOrUnsetProperty(String value) {
+            if (value == null) {
+                System.getProperties().remove(propertyName);
+            } else {
+                System.setProperty(propertyName, value);
+            }
+        }
+    }
+}

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/TestUtils.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/TestUtils.java
@@ -15,11 +15,19 @@
  */
 package org.glassfish.grizzly.http;
 
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
 /**
  *
  * @author Ondro Mihalyi
  */
 public class TestUtils {
+
+    private TestUtils() {
+        // Prevent instantiation
+    }
+
     public static class SystemPropertyToggle {
         private final String propertyName;
         private final Boolean propertyEnabled;
@@ -51,10 +59,40 @@ public class TestUtils {
 
         private void setOrUnsetProperty(String value) {
             if (value == null) {
-                System.getProperties().remove(propertyName);
+                System.clearProperty(propertyName);
             } else {
                 System.setProperty(propertyName, value);
             }
         }
+    }
+
+    /**
+     * Repeatedly attempts to execute the given action. If the action throws an exception or assertion error,
+     * it pauses and retries until the timeout is reached.
+     *
+     * @param action        the task to execute
+     * @param timeoutMillis the maximum time to wait in milliseconds
+     * @param sleepMillis   the pause duration between retries in milliseconds
+     * @param <T>           the type of the result
+     * @return the result of the action if it succeeds before the timeout
+     * @throws Exception if the timeout is exceeded, the last thrown exception is rethrown
+     */
+    @SuppressWarnings("SleepWhileInLoop")
+    public static <T> T retryUntilSuccess(Callable<T> action, Duration timeout, Duration sleep) throws Exception {
+        final long startTime = System.currentTimeMillis();
+        Exception lastException = null;
+        final long timeoutMillis = timeout.toMillis();
+        final long sleepMillis = sleep.toMillis();
+
+        while (System.currentTimeMillis() - startTime <= timeoutMillis) {
+            try {
+                return action.call();
+            } catch (Exception t) {
+                lastException = t;
+            }
+            Thread.sleep(sleepMillis);
+        }
+
+        throw lastException;
     }
 }


### PR DESCRIPTION
Also added tests to cover handling corrupted header values. They fail if validation is disabled.