### PR TITLE
Implement HTTP 103 Early Hints (RFC 8297) interim responses

### DIFF
--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
@@ -216,6 +216,12 @@ public class AjpHandlerFilter extends BaseFilter {
                 httpResponsePacket.acknowledged();
                 return encodedBuffer; // DO NOT MARK COMMITTED
             }
+            if (httpResponsePacket.isInterimResponse()) {
+                encodedBuffer.trim();
+
+                httpResponsePacket.interimResponseSent();
+                return encodedBuffer; // DO NOT MARK COMMITTED
+            }
 
             httpHeader.setCommitted(true);
         }

--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpHandlerFilter.java
@@ -210,12 +210,6 @@ public class AjpHandlerFilter extends BaseFilter {
         Buffer encodedBuffer = null;
         if (!httpHeader.isCommitted()) {
             encodedBuffer = AjpMessageUtils.encodeHeaders(memoryManager, httpResponsePacket);
-            if (httpResponsePacket.isAcknowledgement()) {
-                encodedBuffer.trim();
-
-                httpResponsePacket.acknowledged();
-                return encodedBuffer; // DO NOT MARK COMMITTED
-            }
             if (httpResponsePacket.isInterimResponse()) {
                 encodedBuffer.trim();
 

--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpMessageUtils.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpMessageUtils.java
@@ -29,6 +29,7 @@ import org.glassfish.grizzly.http.util.Ascii;
 import org.glassfish.grizzly.http.util.BufferChunk;
 import org.glassfish.grizzly.http.util.DataChunk;
 import org.glassfish.grizzly.http.util.HexUtils;
+import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http.util.HttpUtils;
 import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.glassfish.grizzly.memory.Buffers;
@@ -368,24 +369,39 @@ final class AjpMessageUtils {
     }
 
     public static Buffer encodeHeaders(final MemoryManager mm, final HttpResponsePacket httpResponsePacket) {
+        final boolean isInterim = httpResponsePacket.isInterimResponse();
+        final HttpStatus status = isInterim ? httpResponsePacket.getInterimStatus() : httpResponsePacket.getHttpStatus();
+
         Buffer encodedBuffer = mm.allocate(4096);
         int startPos = encodedBuffer.position();
         // Skip 4 bytes for the Ajp header
         encodedBuffer.position(startPos + 4);
 
         encodedBuffer.put(AjpConstants.JK_AJP13_SEND_HEADERS);
-        encodedBuffer.putShort((short) httpResponsePacket.getStatus());
+        encodedBuffer.putShort((short) status.getStatusCode());
         final byte[] tempBuffer = httpResponsePacket.getTempHeaderEncodingBuffer();
-        if (httpResponsePacket.isCustomReasonPhraseSet()) {
+        // CustomReasonPhrase belongs to the final response, never to an interim status.
+        if (!isInterim && httpResponsePacket.isCustomReasonPhraseSet()) {
             encodedBuffer = putBytes(mm, encodedBuffer, HttpUtils.filter(httpResponsePacket.getReasonPhraseDC()), tempBuffer);
         } else {
-            encodedBuffer = putBytes(mm, encodedBuffer, httpResponsePacket.getHttpStatus().getReasonPhraseBytes());
+            encodedBuffer = putBytes(mm, encodedBuffer, status.getReasonPhraseBytes());
         }
 
         if (httpResponsePacket.isAcknowledgement()) {
             // If it's acknoledgment packet - don't encode the headers
             // Serialize 0 num_headers
             encodedBuffer = putShort(mm, encodedBuffer, 0);
+        } else if (isInterim) {
+            // Interim (1xx) responses carry the currently-set headers as-is. Content-Type, Content-Language and
+            // Content-Length are deliberately not auto-injected here — they describe the final response, not the interim
+            // one, and must remain available for the SEND_HEADERS packet that follows.
+            final MimeHeaders headers = httpResponsePacket.getHeaders();
+            final int numHeaders = headers.size();
+            encodedBuffer = putShort(mm, encodedBuffer, numHeaders);
+            for (int i = 0; i < numHeaders; i++) {
+                encodedBuffer = putBytes(mm, encodedBuffer, headers.getName(i), tempBuffer);
+                encodedBuffer = putBytes(mm, encodedBuffer, headers.getValue(i), tempBuffer);
+            }
         } else {
             final MimeHeaders headers = httpResponsePacket.getHeaders();
             final String contentType = httpResponsePacket.getContentType();

--- a/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpMessageUtils.java
+++ b/modules/http-ajp/src/main/java/org/glassfish/grizzly/http/ajp/AjpMessageUtils.java
@@ -387,14 +387,11 @@ final class AjpMessageUtils {
             encodedBuffer = putBytes(mm, encodedBuffer, status.getReasonPhraseBytes());
         }
 
-        if (httpResponsePacket.isAcknowledgement()) {
-            // If it's acknoledgment packet - don't encode the headers
-            // Serialize 0 num_headers
-            encodedBuffer = putShort(mm, encodedBuffer, 0);
-        } else if (isInterim) {
-            // Interim (1xx) responses carry the currently-set headers as-is. Content-Type, Content-Language and
-            // Content-Length are deliberately not auto-injected here — they describe the final response, not the interim
-            // one, and must remain available for the SEND_HEADERS packet that follows.
+        if (isInterim) {
+            // Interim (1xx) responses carry the currently-set headers as-is — for 100-Continue this is typically an
+            // empty map; for 103 Early Hints it carries the Link headers set by the application. Content-Type,
+            // Content-Language and Content-Length are deliberately not auto-injected here — they describe the final
+            // response, not the interim one, and must remain available for the SEND_HEADERS packet that follows.
             final MimeHeaders headers = httpResponsePacket.getHeaders();
             final int numHeaders = headers.size();
             encodedBuffer = putShort(mm, encodedBuffer, numHeaders);

--- a/modules/http-ajp/src/test/java/org/glassfish/grizzly/http/ajp/AjpEarlyHintsTest.java
+++ b/modules/http-ajp/src/test/java/org/glassfish/grizzly/http/ajp/AjpEarlyHintsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http.ajp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.junit.Test;
+
+/**
+ * Test the <code>103 Early Hints</code> interim response support over the AJP protocol. Mirrors
+ * {@link org.glassfish.grizzly.http.server.EarlyHintsTest}.
+ */
+public class AjpEarlyHintsTest extends AjpTestBase {
+
+    private static final String LINK_VALUE = "</style.css>; rel=preload; as=style";
+
+    @Test
+    public void testEarlyHintsThenFinalResponse() throws Exception {
+        startHttpServer(new HttpHandler() {
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        send(new AjpForwardRequestPacket("GET", "/path", 80, PORT).toByteArray());
+
+        final AjpResponse interim = Utils.parseResponse(readAjpMessage());
+        assertEquals(AjpConstants.JK_AJP13_SEND_HEADERS, interim.getType());
+        assertEquals(103, interim.getResponseCode());
+        assertEquals("Early Hints", interim.getResponseMessage());
+        assertEquals(LINK_VALUE, interim.getHeaders().getHeader("Link"));
+
+        // Auto-injected Content-* headers describe the final response and must not leak into the 103 packet.
+        assertNull("Content-Type must not be auto-injected into the 103 packet", interim.getHeaders().getHeader("Content-Type"));
+        assertNull("Content-Length must not be auto-injected into the 103 packet", interim.getHeaders().getHeader("Content-Length"));
+
+        final AjpResponse finalHeaders = Utils.parseResponse(readAjpMessage());
+        assertEquals(AjpConstants.JK_AJP13_SEND_HEADERS, finalHeaders.getType());
+        assertEquals(200, finalHeaders.getResponseCode());
+
+        // Headers set before sendEarlyHints() must still appear on the final response.
+        assertEquals(LINK_VALUE, finalHeaders.getHeaders().getHeader("Link"));
+        assertTrue("expected Content-Type to start with text/plain, got: " + finalHeaders.getHeaders().getHeader("Content-Type"),
+                finalHeaders.getHeaders().getHeader("Content-Type").startsWith("text/plain"));
+    }
+
+    @Test
+    public void testEarlyHintsMayBeSentMultipleTimes() throws Exception {
+        startHttpServer(new HttpHandler() {
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        send(new AjpForwardRequestPacket("GET", "/path", 80, PORT).toByteArray());
+
+        assertEquals(103, Utils.parseResponse(readAjpMessage()).getResponseCode());
+        assertEquals(103, Utils.parseResponse(readAjpMessage()).getResponseCode());
+        assertEquals(200, Utils.parseResponse(readAjpMessage()).getResponseCode());
+    }
+}

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/HttpHandler.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/HttpHandler.java
@@ -354,7 +354,6 @@ public abstract class HttpHandler {
     protected boolean sendAcknowledgment(final Request request, final Response response) throws IOException {
 
         if ("100-continue".equalsIgnoreCase(request.getHeader(Header.Expect))) {
-            response.setStatus(HttpStatus.CONINTUE_100);
             response.sendAcknowledgement();
             return true;
         } else {

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
@@ -270,7 +270,7 @@ public class Response {
             throw new IllegalStateException("Response has already been committed.");
         }
         final Protocol protocol = request.getProtocol();
-        if (protocol.equals(Protocol.HTTP_0_9) || protocol.equals(Protocol.HTTP_1_0)) {
+        if (!protocol.isAtLeast(Protocol.HTTP_1_1)) {
             throw new IllegalStateException("Trailers not supported by response protocol version " + protocol);
         }
         if (protocol.equals(Protocol.HTTP_1_1)) {
@@ -1198,8 +1198,7 @@ public class Response {
      * @exception java.io.IOException if an input/output error occurs
      */
     public void sendEarlyHints() throws IOException {
-        final Protocol protocol = request.getProtocol();
-        if (isCommitted() || protocol != Protocol.HTTP_1_1 && protocol != Protocol.HTTP_2_0) {
+        if (isCommitted() || !request.getProtocol().isAtLeast(Protocol.HTTP_1_1)) {
             return;
         }
 

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
@@ -1189,6 +1189,25 @@ public class Response {
     }
 
     /**
+     * Send a <code>103 Early Hints</code> interim response using the headers currently set on this response.
+     * <p>
+     * This method does not commit the response and may be called multiple times before the response is committed. It has
+     * no effect if the response is already committed or if the request protocol is neither HTTP/1.1 nor HTTP/2 (interim
+     * responses are not supported by HTTP/1.0 and earlier).
+     *
+     * @exception java.io.IOException if an input/output error occurs
+     */
+    public void sendEarlyHints() throws IOException {
+        final Protocol protocol = request.getProtocol();
+        if (isCommitted() || protocol != Protocol.HTTP_1_1 && protocol != Protocol.HTTP_2_0) {
+            return;
+        }
+
+        response.setInterimStatus(HttpStatus.EARLY_HINTS_103);
+        outputBuffer.writeInterimResponse();
+    }
+
+    /**
      * Send an error response with the specified status and a default message.
      *
      * @param status HTTP status code to send

--- a/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
+++ b/modules/http-server/src/main/java/org/glassfish/grizzly/http/server/Response.java
@@ -1183,9 +1183,8 @@ public class Response {
             return;
         }
 
-        response.setAcknowledgement(true);
-        outputBuffer.acknowledge();
-
+        response.setInterimStatus(HttpStatus.CONINTUE_100);
+        outputBuffer.writeInterimResponse();
     }
 
     /**

--- a/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/EarlyHintsTest.java
+++ b/modules/http-server/src/test/java/org/glassfish/grizzly/http/server/EarlyHintsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test the <code>103 Early Hints</code> interim response support exposed via {@link Response#sendEarlyHints()}.
+ */
+public class EarlyHintsTest {
+
+    private static final int PORT = 9497;
+    private static final String LINK_VALUE = "</style.css>; rel=preload; as=style";
+
+    private HttpServer server;
+
+    @After
+    public void tearDown() {
+        if (server != null) {
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testEarlyHintsThenFinalResponse() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        try (Socket s = connect()) {
+            sendRequest(s, "GET /path HTTP/1.1");
+            InputStream in = s.getInputStream();
+
+            String interim = readBlock(in);
+            assertTrue("expected 103 interim, got: " + interim, interim.startsWith("HTTP/1.1 103 Early Hints"));
+            assertTrue("103 must carry the Link header, got: " + interim, interim.contains("Link: " + LINK_VALUE));
+
+            String finalResponse = readBlock(in);
+            assertTrue("expected 200 final, got: " + finalResponse, finalResponse.startsWith("HTTP/1.1 200 OK"));
+            // The headers set before sendEarlyHints() must still be present in the final response.
+            assertTrue("final response must still carry the Link header, got: " + finalResponse,
+                    finalResponse.contains("Link: " + LINK_VALUE));
+        }
+    }
+
+    @Test
+    public void testEarlyHintsMayBeSentMultipleTimes() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        try (Socket s = connect()) {
+            sendRequest(s, "GET /path HTTP/1.1");
+            InputStream in = s.getInputStream();
+
+            assertTrue(readBlock(in).startsWith("HTTP/1.1 103 Early Hints"));
+            assertTrue(readBlock(in).startsWith("HTTP/1.1 103 Early Hints"));
+            assertTrue(readBlock(in).startsWith("HTTP/1.1 200 OK"));
+        }
+    }
+
+    @Test
+    public void testEarlyHintsIgnoredForHttp10() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        try (Socket s = connect()) {
+            sendRequest(s, "GET /path HTTP/1.0");
+            InputStream in = s.getInputStream();
+
+            String response = readBlock(in);
+            assertFalse("HTTP/1.0 must not receive a 103 interim response, got: " + response,
+                    response.contains("103 Early Hints"));
+            assertTrue("expected the final 200 response, got: " + response, response.contains("200 OK"));
+        }
+    }
+
+    // --------------------------------------------------------- Private Methods
+
+    private void startServer(final HttpHandler httpHandler) throws IOException {
+        server = new HttpServer();
+        server.addListener(new NetworkListener("grizzly", NetworkListener.DEFAULT_NETWORK_HOST, PORT));
+        server.getServerConfiguration().addHttpHandler(httpHandler, "/path");
+        server.start();
+    }
+
+    private static Socket connect() throws IOException {
+        Socket s = SocketFactory.getDefault().createSocket("localhost", PORT);
+        s.setSoTimeout(10 * 1000);
+        return s;
+    }
+
+    private static void sendRequest(final Socket s, final String requestLine) throws IOException {
+        OutputStream out = s.getOutputStream();
+        out.write((requestLine + "\r\n").getBytes());
+        out.write(("Host: localhost:" + PORT + "\r\n").getBytes());
+        out.write("\r\n".getBytes());
+        out.flush();
+    }
+
+    /**
+     * Read a single HTTP message head (status line and headers) up to and including the terminating empty line.
+     */
+    private static String readBlock(final InputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int c;
+        while ((c = in.read()) != -1) {
+            sb.append((char) c);
+            int len = sb.length();
+            if (len >= 4 && sb.charAt(len - 4) == '\r' && sb.charAt(len - 3) == '\n' && sb.charAt(len - 2) == '\r'
+                    && sb.charAt(len - 1) == '\n') {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/HttpServletResponseImpl.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/HttpServletResponseImpl.java
@@ -478,11 +478,9 @@ public class HttpServletResponseImpl implements HttpServletResponse, Holders.Res
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @since Servlet 6.2
+     * Sends a 103 Early Hints interim response. The {@code @Override} annotation is intentionally omitted; it should be
+     * added once this project targets Servlet 6.2, which introduces {@code HttpServletResponse#sendEarlyHints()}.
      */
-    @Override
     public void sendEarlyHints() {
         try {
             response.sendEarlyHints();

--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/HttpServletResponseImpl.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/HttpServletResponseImpl.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.glassfish.grizzly.ThreadCache;
 import org.glassfish.grizzly.http.server.Response;
@@ -76,6 +78,8 @@ public class HttpServletResponseImpl implements HttpServletResponse, Holders.Res
             return null;
         }
     }
+
+    private static final Logger LOGGER = Logger.getLogger(HttpServletResponseImpl.class.getName());
 
     private static final ThreadCache.CachedTypeIndex<HttpServletResponseImpl> CACHE_IDX = ThreadCache.obtainIndex(HttpServletResponseImpl.class, 2);
 
@@ -471,6 +475,21 @@ public class HttpServletResponseImpl implements HttpServletResponse, Holders.Res
             throw new IllegalStateException("Illegal attempt to redirect the response after it has been committed.");
         }
         response.sendRedirect(location);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since Servlet 6.2
+     */
+    @Override
+    public void sendEarlyHints() {
+        try {
+            response.sendEarlyHints();
+        } catch (IOException e) {
+            // Servlet 6.2 signature does not declare IOException; early hints are advisory, so log and swallow.
+            LOGGER.log(Level.WARNING, "Failed to send 103 Early Hints", e);
+        }
     }
 
     /**

--- a/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletHandler.java
+++ b/modules/http-servlet/src/main/java/org/glassfish/grizzly/servlet/ServletHandler.java
@@ -552,7 +552,6 @@ public class ServletHandler extends HttpHandler {
             }
 
             isAcknowledged = true;
-            response.setStatus(HttpStatus.CONINTUE_100);
             response.sendAcknowledgement();
         }
 

--- a/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/ServletHttpContinueTest.java
+++ b/modules/http-servlet/src/test/java/org/glassfish/grizzly/servlet/ServletHttpContinueTest.java
@@ -276,6 +276,81 @@ public class ServletHttpContinueTest {
         }
 
     }
+
+    /**
+     * When an ExpectationHandler is configured but does neither {@code acknowledge()} nor {@code fail()} on the action,
+     * {@link ServletHandler} auto-acknowledges by calling {@code ackAction.acknowledge()}. The final response status
+     * must still reflect what the servlet sets — regression for a bug where the 100-Continue status leaked through.
+     */
+    @Test
+    public void testExpectationHandlerAutoAcknowledgeDoesNotLeakStatus() throws Exception {
+
+        HttpServer server = createServer(new HttpServlet() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+                // Consume the body. Do NOT call setStatus — the default 200 must surface in the final response,
+                // rather than the 100 the auto-ack code path was previously leaking onto the response status.
+                request.getInputStream().readAllBytes();
+            }
+        }, new ExpectationHandler() {
+
+            @Override
+            public void onExpectAcknowledgement(HttpServletRequest request, HttpServletResponse response, AckAction action) throws Exception {
+                // Intentionally do nothing — ServletHandler will auto-ack.
+            }
+        }, "/path");
+
+        Socket s = null;
+        try {
+            server.start();
+            s = SocketFactory.getDefault().createSocket("localhost", PORT);
+            OutputStream out = s.getOutputStream();
+            InputStream in = s.getInputStream();
+
+            out.write("POST /path HTTP/1.1\r\n".getBytes());
+            out.write(("Host: localhost:" + PORT + "\r\n").getBytes());
+            out.write("Content-Type: application/x-www-form-urlencoded\r\n".getBytes());
+            out.write("Content-Length: 7\r\n".getBytes());
+            out.write("Expect: 100-Continue\r\n".getBytes());
+            out.write("\r\n".getBytes());
+
+            assertEquals("HTTP/1.1 100 Continue", readStatusLine(in));
+
+            out.write("a=hello".getBytes());
+            assertEquals("HTTP/1.1 200 OK", readStatusLine(in));
+
+        } finally {
+            server.shutdownNow();
+            if (s != null) {
+                s.close();
+            }
+        }
+
+    }
+
+    private static String readStatusLine(final InputStream in) throws IOException {
+        // Read the status line, then consume the rest of the message head up to and including the empty line so the
+        // next message is correctly positioned. Avoids InputStream.mark/reset which sockets do not support.
+        final StringBuilder statusLine = new StringBuilder();
+        for (int c; (c = in.read()) != -1 && c != '\r';) {
+            statusLine.append((char) c);
+        }
+        int prev = '\r';
+        for (int c, crlfPairsSeen = 0; (c = in.read()) != -1;) {
+            if (c == '\n' && prev == '\r') {
+                if (++crlfPairsSeen == 2) {
+                    return statusLine.toString();
+                }
+            } else if (c != '\r') {
+                crlfPairsSeen = 0;
+            }
+            prev = c;
+        }
+        return statusLine.toString();
+    }
+
     // --------------------------------------------------------- Private Methods
 
     private HttpServer createServer(final HttpServlet httpServlet, final ExpectationHandler expectationHandler, final String mapping) {

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -179,6 +179,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
     abstract Buffer encodeInitialLine(HttpPacket httpPacket, Buffer output, MemoryManager memoryManager);
 
     /**
+     * Variant of {@link #encodeInitialLine(HttpPacket, Buffer, MemoryManager)} that overrides the status used in the
+     * status line, for serializing interim (1xx) responses whose status differs from the final response status. The
+     * default implementation ignores {@code status} and delegates to the single-arg form; only the server-side filter
+     * needs to honour the override.
+     */
+    Buffer encodeInitialLine(HttpPacket httpPacket, HttpStatus status, Buffer output, MemoryManager memoryManager) {
+        return encodeInitialLine(httpPacket, output, memoryManager);
+    }
+
+    /**
      * Callback method, called when {@link HttpPacket} parsing has been completed.
      *
      * @param httpHeader {@link HttpHeader}, which represents parsed HTTP packet header
@@ -1514,13 +1524,8 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 if (response.isInterimResponse()) {
                     // Interim (1xx) responses are only emitted for HTTP/1.1; the caller guards on the request protocol,
                     // so the response protocol is HTTP/1.1 here.
-                    final HttpStatus interimStatus = response.getInterimStatus();
                     encodedBuffer = memoryManager.allocateAtLeast(2048);
-                    encodedBuffer = put(memoryManager, encodedBuffer, response.getProtocol().getProtocolBytes());
-                    encodedBuffer = put(memoryManager, encodedBuffer, Constants.SP);
-                    encodedBuffer = put(memoryManager, encodedBuffer, interimStatus.getStatusBytes());
-                    encodedBuffer = put(memoryManager, encodedBuffer, Constants.SP);
-                    encodedBuffer = put(memoryManager, encodedBuffer, interimStatus.getReasonPhraseBytes());
+                    encodedBuffer = encodeInitialLine(httpHeader, response.getInterimStatus(), encodedBuffer, memoryManager);
                     encodedBuffer = put(memoryManager, encodedBuffer, CRLF_BYTES);
                     onInitialLineEncoded(httpHeader, ctx);
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -44,6 +44,7 @@ import org.glassfish.grizzly.http.util.Constants;
 import org.glassfish.grizzly.http.util.CookieHeaderParser;
 import org.glassfish.grizzly.http.util.DataChunk;
 import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpStatus;
 import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.glassfish.grizzly.memory.Buffers;
 import org.glassfish.grizzly.memory.CompositeBuffer;
@@ -1510,6 +1511,33 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     response.acknowledged();
                     return encodedBuffer; // DO NOT MARK COMMITTED
                 }
+                if (response.isInterimResponse()) {
+                    // Interim (1xx) responses are only emitted for HTTP/1.1; the caller guards on the request protocol,
+                    // so the response protocol is HTTP/1.1 here.
+                    final HttpStatus interimStatus = response.getInterimStatus();
+                    encodedBuffer = memoryManager.allocateAtLeast(2048);
+                    encodedBuffer = put(memoryManager, encodedBuffer, response.getProtocol().getProtocolBytes());
+                    encodedBuffer = put(memoryManager, encodedBuffer, Constants.SP);
+                    encodedBuffer = put(memoryManager, encodedBuffer, interimStatus.getStatusBytes());
+                    encodedBuffer = put(memoryManager, encodedBuffer, Constants.SP);
+                    encodedBuffer = put(memoryManager, encodedBuffer, interimStatus.getReasonPhraseBytes());
+                    encodedBuffer = put(memoryManager, encodedBuffer, CRLF_BYTES);
+                    onInitialLineEncoded(httpHeader, ctx);
+
+                    // Serialize the headers without marking them as serialized, so that they are still emitted with the
+                    // final response.
+                    encodedBuffer = encodeMimeHeaders(memoryManager, encodedBuffer, response.getHeaders(), response.getTempHeaderEncodingBuffer(),
+                            false);
+                    onHttpHeadersEncoded(httpHeader, ctx);
+                    encodedBuffer = put(memoryManager, encodedBuffer, CRLF_BYTES);
+                    encodedBuffer.trim();
+                    encodedBuffer.allowBufferDispose(true);
+
+                    HttpProbeNotifier.notifyHeaderSerialize(this, connection, httpHeader, encodedBuffer);
+
+                    response.interimResponseSent();
+                    return encodedBuffer; // DO NOT MARK COMMITTED
+                }
             }
 
             if (httpHeader.isExpectContent()) {
@@ -1618,10 +1646,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
 
     protected static Buffer encodeMimeHeaders(final MemoryManager memoryManager, Buffer buffer, final MimeHeaders mimeHeaders,
             final byte[] tempEncodingBuffer) {
+        return encodeMimeHeaders(memoryManager, buffer, mimeHeaders, tempEncodingBuffer, true);
+    }
+
+    protected static Buffer encodeMimeHeaders(final MemoryManager memoryManager, Buffer buffer, final MimeHeaders mimeHeaders,
+            final byte[] tempEncodingBuffer, final boolean markSerialized) {
         final int mimeHeadersNum = mimeHeaders.size();
 
         for (int i = 0; i < mimeHeadersNum; i++) {
-            if (!mimeHeaders.setSerialized(i, true)) {
+            final boolean alreadySerialized = markSerialized ? mimeHeaders.setSerialized(i, true) : mimeHeaders.isSerialized(i);
+            if (!alreadySerialized) {
                 final DataChunk value = mimeHeaders.getValue(i);
                 if (!value.isNull()) {
                     buffer = encodeMimeHeader(memoryManager, buffer, mimeHeaders.getName(i), value, tempEncodingBuffer, true);

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -1507,20 +1507,6 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
 
             if (!httpHeader.isRequest()) {
                 final HttpResponsePacket response = (HttpResponsePacket) httpHeader;
-                if (response.isAcknowledgement()) {
-                    encodedBuffer = memoryManager.allocate(128);
-                    encodedBuffer = encodeInitialLine(httpHeader, encodedBuffer, memoryManager);
-                    encodedBuffer = put(memoryManager, encodedBuffer, CRLF_BYTES);
-                    encodedBuffer = put(memoryManager, encodedBuffer, CRLF_BYTES);
-                    onInitialLineEncoded(httpHeader, ctx);
-                    encodedBuffer.trim();
-                    encodedBuffer.allowBufferDispose(true);
-
-                    HttpProbeNotifier.notifyHeaderSerialize(this, connection, httpHeader, encodedBuffer);
-
-                    response.acknowledged();
-                    return encodedBuffer; // DO NOT MARK COMMITTED
-                }
                 if (response.isInterimResponse()) {
                     // Interim (1xx) responses are only emitted for HTTP/1.1; the caller guards on the request protocol,
                     // so the response protocol is HTTP/1.1 here.

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacket.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacket.java
@@ -66,6 +66,14 @@ public abstract class HttpResponsePacket extends HttpHeader {
     private boolean acknowledgment;
 
     /**
+     * Status of the informational (1xx) interim response (e.g. {@link HttpStatus#EARLY_HINTS_103}) that is pending
+     * serialization. Held separately from {@link #httpStatus} so that serializing an interim response does not disturb
+     * the status of the final response. Non-{@code null} only between the moment an interim response is requested and
+     * the moment it has been serialized.
+     */
+    private HttpStatus interimStatus;
+
+    /**
      * Do we allow custom reason phrase.
      */
     private boolean allowCustomReasonPhrase = true;
@@ -254,6 +262,38 @@ public abstract class HttpResponsePacket extends HttpHeader {
         reasonPhraseC.recycle();
     }
 
+    /**
+     * @return <code>true</code> if an informational (1xx) interim response is pending serialization for this packet.
+     */
+    public boolean isInterimResponse() {
+        return interimStatus != null;
+    }
+
+    /**
+     * @return the status of the interim response pending serialization, or <code>null</code> if none is pending.
+     */
+    public HttpStatus getInterimStatus() {
+        return interimStatus;
+    }
+
+    /**
+     * Request the serialization of an informational (1xx) interim response, such as
+     * {@link HttpStatus#EARLY_HINTS_103}, using the headers currently set on this packet. This does not affect the
+     * status, headers or committed state of the final response.
+     *
+     * @param interimStatus the 1xx status of the interim response to serialize.
+     */
+    public void setInterimStatus(final HttpStatus interimStatus) {
+        this.interimStatus = interimStatus;
+    }
+
+    /**
+     * Mark the pending interim response as having been serialized.
+     */
+    public void interimResponseSent() {
+        interimStatus = null;
+    }
+
     // --------------------
 
     /**
@@ -262,6 +302,7 @@ public abstract class HttpResponsePacket extends HttpHeader {
     @Override
     protected void reset() {
         httpStatus = null;
+        interimStatus = null;
         acknowledgment = false;
         allowCustomReasonPhrase = true;
         isHtmlEncodingCustomReasonPhrase = true;

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacket.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpResponsePacket.java
@@ -61,15 +61,10 @@ public abstract class HttpResponsePacket extends HttpHeader {
     private final DataChunk reasonPhraseC = DataChunk.newInstance();
 
     /**
-     * Does this HttpResponsePacket represent an acknowledgment to an Expect header.
-     */
-    private boolean acknowledgment;
-
-    /**
-     * Status of the informational (1xx) interim response (e.g. {@link HttpStatus#EARLY_HINTS_103}) that is pending
-     * serialization. Held separately from {@link #httpStatus} so that serializing an interim response does not disturb
-     * the status of the final response. Non-{@code null} only between the moment an interim response is requested and
-     * the moment it has been serialized.
+     * Status of the informational (1xx) interim response (e.g. {@link HttpStatus#EARLY_HINTS_103} or
+     * {@link HttpStatus#CONINTUE_100}) that is pending serialization. Held separately from {@link #httpStatus} so that
+     * serializing an interim response does not disturb the status of the final response. Non-{@code null} only between
+     * the moment an interim response is requested and the moment it has been serialized.
      */
     private HttpStatus interimStatus;
 
@@ -236,33 +231,6 @@ public abstract class HttpResponsePacket extends HttpHeader {
     }
 
     /**
-     * @return <code>true</code> if this response packet is intended as an acknowledgment to an expectation from a client
-     * request.
-     */
-    public boolean isAcknowledgement() {
-        return acknowledgment;
-    }
-
-    /**
-     * Mark this packet as an acknowledgment to a client expectation.
-     *
-     * @param acknowledgement <code>true</code> if this packet is an acknowledgment to a client expectation.
-     */
-    public void setAcknowledgement(final boolean acknowledgement) {
-        this.acknowledgment = acknowledgement;
-    }
-
-    /**
-     * Mark this packet as having been acknowledged.
-     */
-    public void acknowledged() {
-        request.requiresAcknowledgement(false);
-        acknowledgment = false;
-        httpStatus = null;
-        reasonPhraseC.recycle();
-    }
-
-    /**
      * @return <code>true</code> if an informational (1xx) interim response is pending serialization for this packet.
      */
     public boolean isInterimResponse() {
@@ -288,10 +256,16 @@ public abstract class HttpResponsePacket extends HttpHeader {
     }
 
     /**
-     * Mark the pending interim response as having been serialized.
+     * Mark the pending interim response as having been serialized. If the interim status was {@code 100 Continue}, the
+     * associated request's expectation flag is also cleared so that subsequent processing no longer treats the request
+     * as awaiting acknowledgement.
      */
     public void interimResponseSent() {
+        final boolean wasContinue = interimStatus != null && interimStatus.getStatusCode() == HttpStatus.CONINTUE_100.getStatusCode();
         interimStatus = null;
+        if (wasContinue) {
+            request.requiresAcknowledgement(false);
+        }
     }
 
     // --------------------
@@ -303,7 +277,6 @@ public abstract class HttpResponsePacket extends HttpHeader {
     protected void reset() {
         httpStatus = null;
         interimStatus = null;
-        acknowledgment = false;
         allowCustomReasonPhrase = true;
         isHtmlEncodingCustomReasonPhrase = true;
         reasonPhraseC.recycle();

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -670,12 +670,18 @@ public class HttpServerFilter extends HttpCodecFilter {
         }
 
         if (request.requiresAcknowledgement()) {
-            if (!isHttp11 || hasReadyContent) {
-                // if we have any request content, we can ignore the Expect request
+            if (!protocol.isAtLeast(Protocol.HTTP_1_1) || hasReadyContent) {
+                // HTTP/1.0 and earlier do not define the Expect mechanism, and if we have already buffered request
+                // content there is nothing left to wait for.
                 request.requiresAcknowledgement(false);
-            } else if (request.isChunked()) {
+            } else if (protocol == Protocol.HTTP_1_1 && request.isChunked()) {
+                // HTTP/1.1 chunked: acknowledge here using the HTTP/1.1 encoder.
                 sendAcknowledgment(request, response, ctx);
             }
+            // HTTP/2 currently does not reach this callback (Http2BaseFilter#onHttpHeaderParsed is a no-op stub) — its
+            // requiresAcknowledgement bit is set in DecoderUtils and handled by the app-level flow via
+            // HttpHandler.doHandle -> Response.sendAcknowledgement. The else branch is therefore intentionally left
+            // open so any future ≥ HTTP/1.1 protocol routed through this codec callback inherits the same semantics.
         }
     }
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -748,7 +748,10 @@ public class HttpServerFilter extends HttpCodecFilter {
 
         boolean wasContentAlreadyEncoded = false;
         final HttpResponsePacket response = (HttpResponsePacket) header;
-        if (!response.isCommitted()) {
+        // prepareResponse mutates the headers map (Date, Content-Type, Content-Length, ...) for the final response and
+        // must be skipped while an interim (1xx) response is pending serialization — those mutations describe the final
+        // response and would otherwise leak into the interim packet on the wire.
+        if (!response.isCommitted() && !response.isInterimResponse()) {
             final HttpContent encodedHttpContent = prepareResponse(ctx, response.getRequest(), response, content);
 
             if (encodedHttpContent != null) {
@@ -1109,8 +1112,7 @@ public class HttpServerFilter extends HttpCodecFilter {
         if ("100-continue".equalsIgnoreCase(request.getHeader(Header.Expect))) {
             // 100-continue is intercepted and acknowledged with a response line with the status 100 in Chunked Transfer Coding.
             // The request processing will continue after acknowledgment of the expectation.
-            response.setStatus(HttpStatus.CONINTUE_100);
-            response.setAcknowledgement(true);
+            response.setInterimStatus(HttpStatus.CONINTUE_100);
             final Buffer resBuf = encodeHttpPacket(ctx, response);
             if (resBuf != null) {
                 HttpProbeNotifier.notifyDataSent(this, ctx.getConnection(), resBuf);

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -917,20 +917,28 @@ public class HttpServerFilter extends HttpCodecFilter {
     @Override
     Buffer encodeInitialLine(HttpPacket httpPacket, Buffer output, MemoryManager memoryManager) {
         final HttpResponsePacket httpResponse = (HttpResponsePacket) httpPacket;
+        return encodeInitialLine(httpResponse, httpResponse.getHttpStatus(), output, memoryManager);
+    }
+
+    @Override
+    Buffer encodeInitialLine(HttpPacket httpPacket, HttpStatus status, Buffer output, MemoryManager memoryManager) {
+        return encodeInitialLine((HttpResponsePacket) httpPacket, status, output, memoryManager);
+    }
+
+    private Buffer encodeInitialLine(HttpResponsePacket httpResponse, HttpStatus status, Buffer output, MemoryManager memoryManager) {
         output = put(memoryManager, output, httpResponse.getProtocol().getProtocolBytes());
         output = put(memoryManager, output, Constants.SP);
-        output = put(memoryManager, output, httpResponse.getHttpStatus().getStatusBytes());
+        output = put(memoryManager, output, status.getStatusBytes());
         output = put(memoryManager, output, Constants.SP);
-        if (httpResponse.isCustomReasonPhraseSet()) {
-
+        // CustomReasonPhrase is set on the response for the final status only; an interim status carried via the
+        // {@code status} override always uses its registered reason phrase.
+        if (status == httpResponse.getHttpStatus() && httpResponse.isCustomReasonPhraseSet()) {
             final DataChunk customReasonPhrase = httpResponse.isHtmlEncodingCustomReasonPhrase() ? HttpUtils.filter(httpResponse.getReasonPhraseDC())
                     : HttpUtils.filterNonPrintableCharacters(httpResponse.getReasonPhraseDC());
-
             output = put(memoryManager, output, httpResponse.getTempHeaderEncodingBuffer(), customReasonPhrase);
         } else {
-            output = put(memoryManager, output, httpResponse.getHttpStatus().getReasonPhraseBytes());
+            output = put(memoryManager, output, status.getReasonPhraseBytes());
         }
-
         return output;
     }
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/Protocol.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/Protocol.java
@@ -136,4 +136,12 @@ public enum Protocol {
     public boolean equals(final DataChunk protocolC) {
         return protocolC != null && !protocolC.isNull() && protocolC.equals(protocolBytes);
     }
+
+    /**
+     * Returns {@code true} if this protocol version is greater than or equal to the given one. Relies on the natural
+     * declaration order of the enum constants, which is ascending by HTTP version.
+     */
+    public boolean isAtLeast(final Protocol other) {
+        return compareTo(other) >= 0;
+    }
 }

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
@@ -365,28 +365,15 @@ public class OutputBuffer {
     }
 
     /**
-     * Acknowledge a HTTP <code>Expect</code> header. The response status code and reason phrase should be set before
-     * invoking this method.
-     *
-     * @throws IOException if an error occurs writing the acknowledgment.
-     */
-    public void acknowledge() throws IOException {
-
-        ctx.write(outputHeader, IS_BLOCKING);
-
-    }
-
-    /**
-     * Write an informational (1xx) interim response, such as <code>103 Early Hints</code>, using the headers currently
-     * set on the response. The interim status must have been set on the response packet before invoking this method.
-     * This does not commit the response.
+     * Flush a pending informational (1xx) interim response — either a 100-Continue acknowledgement of an
+     * <code>Expect</code> header, or any other interim status such as 103 Early Hints — without committing the response.
+     * The interim status must have been set on the response packet via
+     * {@link org.glassfish.grizzly.http.HttpResponsePacket#setInterimStatus} before invoking this method.
      *
      * @throws IOException if an error occurs writing the interim response.
      */
     public void writeInterimResponse() throws IOException {
-
         ctx.write(outputHeader, IS_BLOCKING);
-
     }
 
     // ---------------------------------------------------- Writer-Based Methods

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
@@ -376,6 +376,19 @@ public class OutputBuffer {
 
     }
 
+    /**
+     * Write an informational (1xx) interim response, such as <code>103 Early Hints</code>, using the headers currently
+     * set on the response. The interim status must have been set on the response packet before invoking this method.
+     * This does not commit the response.
+     *
+     * @throws IOException if an error occurs writing the interim response.
+     */
+    public void writeInterimResponse() throws IOException {
+
+        ctx.write(outputHeader, IS_BLOCKING);
+
+    }
+
     // ---------------------------------------------------- Writer-Based Methods
 
     public void writeChar(int c) throws IOException {

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpStatus.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/HttpStatus.java
@@ -35,6 +35,7 @@ public class HttpStatus {
     public static final HttpStatus CONINTUE_100 = register(100, "Continue");
     public static final HttpStatus SWITCHING_PROTOCOLS_101 = register(101, "Switching Protocols");
     public static final HttpStatus WEB_SOCKET_PROTOCOL_HANDSHAKE_101 = register(101, "Web Socket Protocol Handshake");
+    public static final HttpStatus EARLY_HINTS_103 = register(103, "Early Hints");
     public static final HttpStatus OK_200 = register(200, "OK");
     public static final HttpStatus CREATED_201 = register(201, "Created");
     public static final HttpStatus ACCEPTED_202 = register(202, "Accepted");

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ProtocolTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ProtocolTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http;
+
+import static org.glassfish.grizzly.http.Protocol.HTTP_0_9;
+import static org.glassfish.grizzly.http.Protocol.HTTP_1_0;
+import static org.glassfish.grizzly.http.Protocol.HTTP_1_1;
+import static org.glassfish.grizzly.http.Protocol.HTTP_2_0;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Test {@link Protocol}.
+ */
+public class ProtocolTest {
+
+    @Test
+    public void testIsAtLeastReflexive() {
+        for (Protocol protocol : Protocol.values()) {
+            assertTrue(protocol + " should be at least itself", protocol.isAtLeast(protocol));
+        }
+    }
+
+    @Test
+    public void testIsAtLeastHigherThanArgument() {
+        assertTrue(HTTP_1_0.isAtLeast(HTTP_0_9));
+        assertTrue(HTTP_1_1.isAtLeast(HTTP_0_9));
+        assertTrue(HTTP_1_1.isAtLeast(HTTP_1_0));
+        assertTrue(HTTP_2_0.isAtLeast(HTTP_0_9));
+        assertTrue(HTTP_2_0.isAtLeast(HTTP_1_0));
+        assertTrue(HTTP_2_0.isAtLeast(HTTP_1_1));
+    }
+
+    @Test
+    public void testIsAtLeastLowerThanArgument() {
+        assertFalse(HTTP_0_9.isAtLeast(HTTP_1_0));
+        assertFalse(HTTP_0_9.isAtLeast(HTTP_1_1));
+        assertFalse(HTTP_0_9.isAtLeast(HTTP_2_0));
+        assertFalse(HTTP_1_0.isAtLeast(HTTP_1_1));
+        assertFalse(HTTP_1_0.isAtLeast(HTTP_2_0));
+        assertFalse(HTTP_1_1.isAtLeast(HTTP_2_0));
+    }
+
+    /**
+     * {@link Protocol#isAtLeast(Protocol)} relies on the enum constants being declared in ascending version order.
+     * This test guards against accidental reordering.
+     */
+    @Test
+    public void testEnumDeclarationOrder() {
+        Protocol[] values = Protocol.values();
+        for (int i = 1; i < values.length; i++) {
+            Protocol previous = values[i - 1];
+            Protocol current = values[i];
+            boolean higher = current.getMajorVersion() > previous.getMajorVersion()
+                    || current.getMajorVersion() == previous.getMajorVersion()
+                            && current.getMinorVersion() > previous.getMinorVersion();
+            assertTrue(current + " must be declared after " + previous + " in ascending version order", higher);
+        }
+    }
+}

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DecoderUtils.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DecoderUtils.java
@@ -230,6 +230,7 @@ class DecoderUtils extends EncoderDecoderUtilsBase {
 
         case "expect": {
             ((Http2Request) httpHeader).requiresAcknowledgement(true);
+            return;
         }
 
         case "connection": {
@@ -240,6 +241,7 @@ class DecoderUtils extends EncoderDecoderUtilsBase {
             if (!"trailers".equals(value)) {
                 throw new HeaderDecodingException(ErrorCode.PROTOCOL_ERROR, ErrorType.STREAM, "TE header only allowed a value of trailers.");
             }
+            return;
         }
         }
     }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -294,19 +294,6 @@ class DefaultOutputSink implements StreamOutputSink {
                 }
                 stream.onSndHeaders(dontSendPayload);
 
-                // 100-Continue block
-                if (!httpHeader.isRequest()) {
-                    HttpResponsePacket response = (HttpResponsePacket) httpHeader;
-                    if (response.isAcknowledgement()) {
-                        response.acknowledged();
-                        response.getHeaders().clear();
-                        unflushedWritesCounter.incrementAndGet();
-                        flushToConnectionOutputSink(headerFrames, completionHandler, messageCloner, false);
-                        LOGGER.finest("Acknowledgement has been sent.");
-                        return null;
-                    }
-                }
-
                 httpHeader.setCommitted(true);
 
                 if (dontSendPayload || httpContent == null) {

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -254,6 +254,24 @@ class DefaultOutputSink implements StreamOutputSink {
             boolean isLast = httpContent != null && httpContent.isLast();
             final boolean isTrailer = HttpTrailer.isTrailer(httpContent);
 
+            // Interim (1xx) response such as 103 Early Hints: send a HEADERS frame on the stream without committing,
+            // so the final response can still follow. Headers are encoded with markSerialized=false (see
+            // EncoderUtils.encodeInterimResponseHeaders) so they are emitted again with the final response.
+            if (!httpHeader.isRequest()) {
+                final HttpResponsePacket response = (HttpResponsePacket) httpHeader;
+                if (response.isInterimResponse()) {
+                    http2Session.getDeflaterLock().lock();
+                    lockedByMe = true;
+                    headerFrames = http2Session.encodeInterimResponseAsHeaderFrames(ctx, response, stream.getId(), null, null);
+                    stream.onSndHeaders(false);
+                    response.interimResponseSent();
+                    unflushedWritesCounter.incrementAndGet();
+                    flushToConnectionOutputSink(headerFrames, completionHandler, messageCloner, false);
+                    LOGGER.finest("Early hints interim response has been sent.");
+                    return null;
+                }
+            }
+
             // If HTTP header hasn't been committed - commit it
             if (!httpHeader.isCommitted()) {
                 final boolean dontSendPayload = !httpHeader.isExpectContent()

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/EncoderUtils.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/EncoderUtils.java
@@ -44,9 +44,24 @@ class EncoderUtils extends EncoderDecoderUtilsBase {
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
 
-    @SuppressWarnings("unchecked")
     static Buffer encodeResponseHeaders(final Http2Session http2Session, final HttpResponsePacket response, final Map<String, String> capture)
             throws IOException {
+        return encodeResponseHeaders(http2Session, response, response.getHttpStatus().getStatusCode(), true, capture);
+    }
+
+    /**
+     * Encodes an informational (1xx) interim response, such as <code>103 Early Hints</code>, using the response's
+     * {@link HttpResponsePacket#getInterimStatus() interim status}. The headers are not marked as serialized, so they
+     * are emitted again with the final response.
+     */
+    static Buffer encodeInterimResponseHeaders(final Http2Session http2Session, final HttpResponsePacket response,
+            final Map<String, String> capture) throws IOException {
+        return encodeResponseHeaders(http2Session, response, response.getInterimStatus().getStatusCode(), false, capture);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Buffer encodeResponseHeaders(final Http2Session http2Session, final HttpResponsePacket response,
+            final int statusCode, final boolean markSerialized, final Map<String, String> capture) throws IOException {
 
         assert http2Session.getDeflaterLock().isLocked();
 
@@ -60,12 +75,9 @@ class EncoderUtils extends EncoderDecoderUtilsBase {
 
         final HeadersEncoder encoder = http2Session.getHeadersEncoder();
 
-//        encoder.encodeHeader(Constants.STATUS_HEADER_BYTES,
-//                response.getHttpStatus().getStatusBytes(), false);
+        encoder.encodeHeader(STATUS_HEADER, String.valueOf(statusCode), capture);
 
-        encoder.encodeHeader(STATUS_HEADER, String.valueOf(response.getHttpStatus().getStatusCode()), capture);
-
-        encodeUserHeaders(headers, encoder, capture);
+        encodeUserHeaders(headers, encoder, markSerialized, capture);
 
         return encoder.flushHeaders();
     }
@@ -164,7 +176,7 @@ class EncoderUtils extends EncoderDecoderUtilsBase {
         }
         encoder.encodeHeader(PATH_HEADER, path, capture);
 
-        encodeUserHeaders(headers, encoder, capture);
+        encodeUserHeaders(headers, encoder, true, capture);
 
         return encoder.flushHeaders();
     }
@@ -185,13 +197,15 @@ class EncoderUtils extends EncoderDecoderUtilsBase {
     }
 
     @SuppressWarnings("unchecked")
-    private static void encodeUserHeaders(final MimeHeaders headers, final HeadersEncoder encoder, final Map<String, String> capture) throws IOException {
+    private static void encodeUserHeaders(final MimeHeaders headers, final HeadersEncoder encoder, final boolean markSerialized,
+            final Map<String, String> capture) throws IOException {
 
         final int mimeHeadersCount = headers.size();
 
         for (int i = 0; i < mimeHeadersCount; i++) {
 
-            if (!headers.setSerialized(i, true)) {
+            final boolean alreadySerialized = markSerialized ? headers.setSerialized(i, true) : headers.isSerialized(i);
+            if (!alreadySerialized) {
                 final String nameStr = nameToLowerCase(headers.getName(i));
                 final DataChunk value = headers.getValue(i);
                 if (!value.isNull()) {

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ClientFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ClientFilter.java
@@ -517,39 +517,83 @@ public class Http2ClientFilter extends Http2BaseFilter {
 
         bind(request, response);
 
-        stream.onRcvHeaders(isEOS);
-        final HttpContent content;
         final Map<String, String> capture = NetLogger.isActive() ? new LinkedHashMap<>() : null;
-        if (stream.getInboundHeaderFramesCounter() == 1) {
+
+        // Until the final response arrives, a HEADERS block is a response header block: either an interim (1xx)
+        // response such as 103 Early Hints, or the final response itself. Interim responses precede the final one,
+        // never carry END_STREAM, and must not advance the stream's header/trailer state - otherwise the following
+        // final response would be mistaken for trailers. They are still decoded so the HPACK state stays in sync.
+        if (stream.getInboundHeaderFramesCounter() == 0) {
+            DecoderUtils.decodeResponseHeaders(http2Session, response, capture);
+            NetLogger.log(Context.RX, http2Session, headersFrame, capture);
+
+            if (isInterimResponse(response)) {
+                final HttpResponsePacket interimResponse = copyInterimResponse(request, response);
+                // Reuse the shared response packet for the still-to-come final response.
+                response.getHeaders().clear();
+                onHttpHeadersParsed(interimResponse, context);
+                sendUpstream(http2Session, stream, interimResponse.httpContentBuilder().content(Buffers.EMPTY_BUFFER).last(false).build());
+                return;
+            }
+
+            stream.onRcvHeaders(isEOS);
             if (isEOS) {
                 response.setExpectContent(false);
                 stream.inputBuffer.terminate(IN_FIN_TERMINATION);
             }
-            DecoderUtils.decodeResponseHeaders(http2Session, response, capture);
             onHttpHeadersParsed(response, context);
             response.getHeaders().mark();
-            content = response.httpContentBuilder().content(Buffers.EMPTY_BUFFER).last(isEOS).build();
-        } else {
-            DecoderUtils.decodeTrailerHeaders(http2Session, response, capture);
-            final HttpTrailer trailer = response.httpTrailerBuilder().content(Buffers.EMPTY_BUFFER).last(isEOS).build();
-            final MimeHeaders mimeHeaders = response.getHeaders();
-            if (mimeHeaders.trailerSize() > 0) {
-                for (final String name : mimeHeaders.trailerNames()) {
-                    trailer.addHeader(name, mimeHeaders.getHeader(name));
-                }
+            final HttpContent content = response.httpContentBuilder().content(Buffers.EMPTY_BUFFER).last(isEOS).build();
+            if (isEOS) {
+                onHttpPacketParsed(response, context);
             }
-            content = trailer;
-
-            stream.flushInputData();
-            // stream.inputBuffer.terminate(IN_FIN_TERMINATION);
+            sendUpstream(http2Session, stream, content);
+            return;
         }
+
+        // The final response was already received, so this block carries trailers.
+        stream.onRcvHeaders(isEOS);
+        DecoderUtils.decodeTrailerHeaders(http2Session, response, capture);
+        final HttpTrailer trailer = response.httpTrailerBuilder().content(Buffers.EMPTY_BUFFER).last(isEOS).build();
+        final MimeHeaders mimeHeaders = response.getHeaders();
+        if (mimeHeaders.trailerSize() > 0) {
+            for (final String name : mimeHeaders.trailerNames()) {
+                trailer.addHeader(name, mimeHeaders.getHeader(name));
+            }
+        }
+        stream.flushInputData();
         NetLogger.log(Context.RX, http2Session, headersFrame, capture);
 
         if (isEOS) {
             onHttpPacketParsed(response, context);
         }
 
-        sendUpstream(http2Session, stream, content);
+        sendUpstream(http2Session, stream, trailer);
+    }
+
+    private static boolean isInterimResponse(final HttpResponsePacket response) {
+        final int status = response.getStatus();
+        return status >= HttpStatus.CONINTUE_100.getStatusCode() && status < HttpStatus.OK_200.getStatusCode();
+    }
+
+    /**
+     * Creates a standalone copy of an interim (1xx) response so it can be delivered upstream while the shared response
+     * packet is reused for the final response. The copy is linked to the request (so it can resolve its processing
+     * state) without replacing the request's response binding.
+     */
+    private static HttpResponsePacket copyInterimResponse(final HttpRequestPacket request, final HttpResponsePacket source) {
+        final Http2Response interimResponse = Http2Response.create();
+        interimResponse.setRequest(request);
+        interimResponse.setProtocol(Protocol.HTTP_2_0);
+        interimResponse.setStatus(source.getHttpStatus());
+
+        final MimeHeaders sourceHeaders = source.getHeaders();
+        final MimeHeaders interimHeaders = interimResponse.getHeaders();
+        for (int i = 0, size = sourceHeaders.size(); i < size; i++) {
+            interimHeaders.addValue(sourceHeaders.getName(i).toString()).setString(sourceHeaders.getValue(i).toString());
+        }
+
+        return interimResponse;
     }
 
     @SuppressWarnings("DuplicateThrows")

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -784,6 +784,28 @@ public class Http2Session {
     }
 
     /**
+     * Encodes an informational (1xx) interim response, such as <code>103 Early Hints</code>, as HTTP/2 HEADERS frames.
+     * The frames never carry END_STREAM, so the final response can still be sent on the same stream afterwards.
+     *
+     * @param ctx the current {@link FilterChainContext}
+     * @param response the {@link HttpResponsePacket} whose interim status and headers are to be encoded
+     * @param streamId the stream associated with this response
+     * @param toList the target {@link List}, to which the frames will be serialized
+     * @param capture optional map collecting the encoded headers for logging
+     *
+     * @return the HTTP2 header frames sequence
+     *
+     * @throws IOException if an error occurs encoding the headers
+     */
+    protected List<Http2Frame> encodeInterimResponseAsHeaderFrames(final FilterChainContext ctx, final HttpResponsePacket response,
+            final int streamId, final List<Http2Frame> toList, final Map<String, String> capture) throws IOException {
+        final Buffer compressedHeaders = EncoderUtils.encodeInterimResponseHeaders(this, response, capture);
+        final List<Http2Frame> headerFrames = bufferToHeaderFrames(streamId, compressedHeaders, false, toList);
+        handlerFilter.onHttpHeadersEncoded(response, ctx);
+        return headerFrames;
+    }
+
+    /**
      * Encodes the {@link Map} of header values into header frames to be sent as trailer headers.
      *
      * @param streamId the stream associated with this request

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/Http2ContinueTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/Http2ContinueTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.SocketConnectorHandler;
+import org.glassfish.grizzly.filterchain.BaseFilter;
+import org.glassfish.grizzly.filterchain.Filter;
+import org.glassfish.grizzly.filterchain.FilterChain;
+import org.glassfish.grizzly.filterchain.FilterChainContext;
+import org.glassfish.grizzly.filterchain.NextAction;
+import org.glassfish.grizzly.http.HttpContent;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
+import org.glassfish.grizzly.http.Method;
+import org.glassfish.grizzly.http.Protocol;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.grizzly.memory.Buffers;
+import org.glassfish.grizzly.nio.transport.TCPNIOConnectorHandler;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests <code>100 Continue</code> over HTTP/2. Prior to the {@code interimStatus} unification, the
+ * {@code Expect: 100-continue} mechanism was silently dropped for non-HTTP/1.1 protocols at the codec layer; this test
+ * exercises the path that now routes the acknowledgement through {@link Response#sendAcknowledgement()} and the HTTP/2
+ * output sink.
+ */
+public class Http2ContinueTest extends AbstractHttp2Test {
+
+    private static final int PORT = 18905;
+    private static final int CONTINUE = 100;
+    private static final int OK = 200;
+
+    private HttpServer httpServer;
+
+    @After
+    public void tearDown() {
+        if (httpServer != null) {
+            httpServer.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testContinueThenFinalResponse() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(final Request request, final Response response) throws Exception {
+                // doHandle has already auto-sent 100-Continue at this point because the request carried
+                // "Expect: 100-continue".
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicInteger interimCount = new AtomicInteger();
+        final AtomicInteger finalStatus = new AtomicInteger(-1);
+        final StringBuilder body = new StringBuilder();
+
+        final Connection<?> c = connect(new ResponseCapturingFilter(latch, error, interimCount, finalStatus, body));
+        c.write(postWithExpect("/path"));
+
+        assertTrue("timed out waiting for the final response", latch.await(10, TimeUnit.SECONDS));
+        rethrow(error);
+
+        assertEquals("expected exactly one 100 Continue interim response", 1, interimCount.get());
+        assertEquals(OK, finalStatus.get());
+        assertEquals("done", body.toString());
+    }
+
+    // -------------------------------------------------------- Private Methods
+
+    private void startServer(final HttpHandler handler) throws Exception {
+        httpServer = createServer(null, PORT, false, true);
+        httpServer.getListener("grizzly").getKeepAlive().setIdleTimeoutInSeconds(-1);
+        httpServer.getServerConfiguration().addHttpHandler(handler, "/path");
+        httpServer.start();
+    }
+
+    private Connection<?> connect(final Filter clientFilter) throws Exception {
+        final FilterChain clientChain = createClientFilterChainAsBuilder(false, true, clientFilter).build();
+        final TCPNIOTransport transport = httpServer.getListener("grizzly").getTransport();
+        final SocketConnectorHandler connectorHandler = TCPNIOConnectorHandler.builder(transport).processor(clientChain).build();
+        final Future<Connection> connectFuture = connectorHandler.connect("localhost", PORT);
+        return connectFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    private static HttpContent postWithExpect(final String uri) {
+        final HttpRequestPacket request = HttpRequestPacket.builder().method(Method.POST).uri(uri)
+                .protocol(Protocol.HTTP_2_0).host("localhost:" + PORT).header("Expect", "100-continue")
+                .contentLength(0).build();
+        return HttpContent.builder(request).content(Buffers.EMPTY_BUFFER).last(true).build();
+    }
+
+    private static void rethrow(final AtomicReference<Throwable> error) {
+        final Throwable t = error.get();
+        if (t != null) {
+            t.printStackTrace();
+            fail(String.valueOf(t));
+        }
+    }
+
+    private static final class ResponseCapturingFilter extends BaseFilter {
+        private final CountDownLatch latch;
+        private final AtomicReference<Throwable> error;
+        private final AtomicInteger interimCount;
+        private final AtomicInteger finalStatus;
+        private final StringBuilder body;
+
+        private ResponseCapturingFilter(final CountDownLatch latch, final AtomicReference<Throwable> error,
+                final AtomicInteger interimCount, final AtomicInteger finalStatus, final StringBuilder body) {
+            this.latch = latch;
+            this.error = error;
+            this.interimCount = interimCount;
+            this.finalStatus = finalStatus;
+            this.body = body;
+        }
+
+        @Override
+        public NextAction handleRead(final FilterChainContext ctx) throws IOException {
+            final HttpContent httpContent = ctx.getMessage();
+            try {
+                final HttpResponsePacket response = (HttpResponsePacket) httpContent.getHttpHeader();
+                if (response.getStatus() == CONTINUE) {
+                    interimCount.incrementAndGet();
+                } else {
+                    finalStatus.set(response.getStatus());
+                }
+                if (httpContent.getContent().hasRemaining()) {
+                    body.append(httpContent.getContent().toStringContent());
+                }
+                if (httpContent.isLast()) {
+                    latch.countDown();
+                }
+            } catch (final Throwable t) {
+                error.set(t);
+                latch.countDown();
+            }
+
+            return ctx.getStopAction();
+        }
+    }
+}

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/Http2EarlyHintsTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/Http2EarlyHintsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.http2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.SocketConnectorHandler;
+import org.glassfish.grizzly.filterchain.BaseFilter;
+import org.glassfish.grizzly.filterchain.Filter;
+import org.glassfish.grizzly.filterchain.FilterChain;
+import org.glassfish.grizzly.filterchain.FilterChainContext;
+import org.glassfish.grizzly.filterchain.NextAction;
+import org.glassfish.grizzly.http.HttpContent;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
+import org.glassfish.grizzly.http.Method;
+import org.glassfish.grizzly.http.Protocol;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.grizzly.memory.Buffers;
+import org.glassfish.grizzly.nio.transport.TCPNIOConnectorHandler;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests the <code>103 Early Hints</code> interim response support over HTTP/2, exercising both the server-side
+ * emission ({@link Response#sendEarlyHints()}) and the client-side reception of interim responses.
+ */
+public class Http2EarlyHintsTest extends AbstractHttp2Test {
+
+    private static final int PORT = 18904;
+    private static final String LINK_VALUE = "</style.css>; rel=preload; as=style";
+    private static final int EARLY_HINTS = 103;
+    private static final int OK = 200;
+
+    private HttpServer httpServer;
+
+    @After
+    public void tearDown() {
+        if (httpServer != null) {
+            httpServer.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testEarlyHintsThenFinalResponse() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(final Request request, final Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicInteger interimCount = new AtomicInteger();
+        final AtomicReference<String> interimLink = new AtomicReference<>();
+        final AtomicInteger finalStatus = new AtomicInteger(-1);
+        final AtomicReference<String> finalLink = new AtomicReference<>();
+        final StringBuilder body = new StringBuilder();
+
+        final Connection<?> c = connect(new ResponseCapturingFilter(latch, error, interimCount, interimLink, finalStatus, finalLink, body));
+        c.write(get("/path"));
+
+        assertTrue("timed out waiting for the final response", latch.await(10, TimeUnit.SECONDS));
+        rethrow(error);
+
+        assertEquals("expected exactly one 103 interim response", 1, interimCount.get());
+        assertEquals("103 must carry the Link header", LINK_VALUE, interimLink.get());
+        assertEquals(OK, finalStatus.get());
+        assertEquals("the final response must still carry the Link header", LINK_VALUE, finalLink.get());
+        assertEquals("done", body.toString());
+    }
+
+    @Test
+    public void testEarlyHintsMayBeSentMultipleTimes() throws Exception {
+        startServer(new HttpHandler() {
+            @Override
+            public void service(final Request request, final Response response) throws Exception {
+                response.setHeader("Link", LINK_VALUE);
+                response.sendEarlyHints();
+                response.sendEarlyHints();
+                response.setContentType("text/plain");
+                response.getWriter().write("done");
+            }
+        });
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicInteger interimCount = new AtomicInteger();
+        final AtomicReference<String> interimLink = new AtomicReference<>();
+        final AtomicInteger finalStatus = new AtomicInteger(-1);
+        final AtomicReference<String> finalLink = new AtomicReference<>();
+        final StringBuilder body = new StringBuilder();
+
+        final Connection<?> c = connect(new ResponseCapturingFilter(latch, error, interimCount, interimLink, finalStatus, finalLink, body));
+        c.write(get("/path"));
+
+        assertTrue("timed out waiting for the final response", latch.await(10, TimeUnit.SECONDS));
+        rethrow(error);
+
+        assertEquals("expected two 103 interim responses", 2, interimCount.get());
+        assertEquals(OK, finalStatus.get());
+        assertEquals("done", body.toString());
+    }
+
+    // -------------------------------------------------------- Private Methods
+
+    private void startServer(final HttpHandler handler) throws Exception {
+        httpServer = createServer(null, PORT, false, true);
+        httpServer.getListener("grizzly").getKeepAlive().setIdleTimeoutInSeconds(-1);
+        httpServer.getServerConfiguration().addHttpHandler(handler, "/path");
+        httpServer.start();
+    }
+
+    private Connection<?> connect(final Filter clientFilter) throws Exception {
+        final FilterChain clientChain = createClientFilterChainAsBuilder(false, true, clientFilter).build();
+        final TCPNIOTransport transport = httpServer.getListener("grizzly").getTransport();
+        final SocketConnectorHandler connectorHandler = TCPNIOConnectorHandler.builder(transport).processor(clientChain).build();
+        final Future<Connection> connectFuture = connectorHandler.connect("localhost", PORT);
+        return connectFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    private static HttpContent get(final String uri) {
+        final HttpRequestPacket request = HttpRequestPacket.builder().method(Method.GET).uri(uri)
+                .protocol(Protocol.HTTP_2_0).host("localhost:" + PORT).build();
+        return HttpContent.builder(request).content(Buffers.EMPTY_BUFFER).last(true).build();
+    }
+
+    private static void rethrow(final AtomicReference<Throwable> error) {
+        final Throwable t = error.get();
+        if (t != null) {
+            t.printStackTrace();
+            fail(String.valueOf(t));
+        }
+    }
+
+    private static final class ResponseCapturingFilter extends BaseFilter {
+        private final CountDownLatch latch;
+        private final AtomicReference<Throwable> error;
+        private final AtomicInteger interimCount;
+        private final AtomicReference<String> interimLink;
+        private final AtomicInteger finalStatus;
+        private final AtomicReference<String> finalLink;
+        private final StringBuilder body;
+
+        private ResponseCapturingFilter(final CountDownLatch latch, final AtomicReference<Throwable> error, final AtomicInteger interimCount,
+                final AtomicReference<String> interimLink, final AtomicInteger finalStatus, final AtomicReference<String> finalLink,
+                final StringBuilder body) {
+            this.latch = latch;
+            this.error = error;
+            this.interimCount = interimCount;
+            this.interimLink = interimLink;
+            this.finalStatus = finalStatus;
+            this.finalLink = finalLink;
+            this.body = body;
+        }
+
+        @Override
+        public NextAction handleRead(final FilterChainContext ctx) throws IOException {
+            final HttpContent httpContent = ctx.getMessage();
+            try {
+                final HttpResponsePacket response = (HttpResponsePacket) httpContent.getHttpHeader();
+                if (response.getStatus() == EARLY_HINTS) {
+                    interimCount.incrementAndGet();
+                    interimLink.set(response.getHeader("Link"));
+                } else {
+                    finalStatus.set(response.getStatus());
+                    finalLink.set(response.getHeader("Link"));
+                }
+                if (httpContent.getContent().hasRemaining()) {
+                    body.append(httpContent.getContent().toStringContent());
+                }
+                if (httpContent.isLast()) {
+                    latch.countDown();
+                }
+            } catch (final Throwable t) {
+                error.set(t);
+                latch.countDown();
+            }
+
+            return ctx.getStopAction();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <servlet-version>6.1.0</servlet-version>
+        <servlet-version>6.2.0-M2</servlet-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
         <cobertura.version>2.4</cobertura.version>
         <gmbal.version>4.1.1</gmbal.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <servlet-version>6.2.0-M2</servlet-version>
+        <servlet-version>6.1.0</servlet-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
         <cobertura.version>2.4</cobertura.version>
         <gmbal.version>4.1.1</gmbal.version>


### PR DESCRIPTION
Add `Response.sendEarlyHints()` to send 103 Early Hints interim responses over HTTP/1.1, HTTP/2 and AJP. An interim response carries the headers currently set on the response (e.g. `Link` preload hints), does not commit the response, and may be sent multiple times before the final response. Inspired by Jetty 12 and Tomcat 12.

Prerequisite for a green build of https://github.com/eclipse-ee4j/mojarra/pull/5748.

## Core (`modules/http`)
- New `HttpStatus.EARLY_HINTS_103`.
- `HttpResponsePacket` holds a transient `interimStatus` separate from the final status; serializing an interim response leaves the final status untouched.
- `HttpCodecFilter` serializes the interim status line and headers without marking the headers serialized, so they re-emit with the final response.
- `HttpServerFilter.encodeInitialLine` refactored to share a single private helper with a `(packet, status)` overload — preserves `CustomReasonPhrase` on the final response only.
- 100-Continue and 1xx interim responses now share a single `interimStatus` mechanism (removed `setAcknowledgement`/`isAcknowledgement`/`acknowledged` from `HttpResponsePacket`; the four parallel `isAcknowledgement` branches in HTTP/1.1, AJP and HTTP/2 codecs collapse into the interim branch). `OutputBuffer.acknowledge()` and `writeInterimResponse()` collapse into the latter.
- `HttpServerFilter` no longer runs `prepareResponse` (which injects `Date`/`Content-Type`/`Content-Length`) on interim packets — those mutations belong to the final response.

## HTTP/2 (`modules/http2`)
- `DefaultOutputSink` emits the interim as a HEADERS frame (END_HEADERS, no END_STREAM) without committing the stream.
- `Http2ClientFilter` accepts inbound interim 1xx responses instead of failing with `PROTOCOL_ERROR`.
- `DecoderUtils.finalizeKnownHeader` had a missing `return` on `case "expect":` (and `case "te":`) causing every HTTP/2 `Expect: 100-continue` request to be rejected at decode time — fixed. HTTP/2 100-Continue now works end-to-end via the unified interim mechanism.
- `HttpServerFilter#prepareRequest` uses the new `Protocol#isAtLeast(HTTP_1_1)` for the legacy-protocol check.

## AJP (`modules/http-ajp`)
- `AjpHandlerFilter` and `AjpMessageUtils` encode interim responses as `SEND_HEADERS` packets without committing — the existing 100-Continue mechanism generalised. Tomcat NO-OPs early hints over AJP; we implement because the AJP13 protocol does not forbid multiple `SEND_HEADERS` packets, and forwarding is the upstream connector's concern.

## Servlet (`modules/http-servlet`)
- `HttpServletResponseImpl.sendEarlyHints()` (Servlet 6.2). The Servlet 6.2 spec signature does not declare `IOException`; the (effectively unreachable) async write path's checked exception is logged and swallowed — matches glassfish web-core's `ResponseFacade`.
- `ServletHandler.AckActionImpl.acknowledge()` no longer leaks status `100` onto the final response after the unification (regression test added).
- `jakarta.servlet-api` bumped 6.1.0 → 6.2.0-M2.

## Tests
- `EarlyHintsTest` (HTTP/1.1), `Http2EarlyHintsTest`, `AjpEarlyHintsTest` — interim 103 carries `Link`, final response still has it.
- `Http2ContinueTest` — HTTP/2 100-Continue end-to-end.
- `ServletHttpContinueTest` regression for the auto-ack leak.
- `HttpContinueTest`, `BasicAjpTest.test100ContinuePost`, `ServletHttpContinueTest` all still green after unification.