### PR TITLE
Send the bad-request response when the request line carried an unrecognised protocol token

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpServerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1088,7 +1088,22 @@ public class HttpServerFilter extends HttpCodecFilter {
             // 400 - Bad request
             HttpStatus.BAD_REQUEST_400.setValues(response);
         }
+        ensureSerializableProtocol(response.getRequest());
         commitAndCloseAsError(ctx, response);
+    }
+
+    /**
+     * The error response has to be serializable whatever the client sent. When the request line carried a protocol
+     * token this implementation does not recognize, {@link HttpHeader#getProtocol()} throws, and here it would throw
+     * from {@link #prepareResponse} while the error response is being encoded - losing the response altogether.
+     * Assume HTTP/1.1 in that case, as {@link #prepareRequest} already does for the 505 it answers.
+     */
+    private static void ensureSerializableProtocol(final HttpRequestPacket request) {
+        try {
+            request.getProtocol();
+        } catch (IllegalStateException unrecognizedProtocol) {
+            request.setProtocol(Protocol.HTTP_1_1);
+        }
     }
 
     /*

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -667,6 +668,37 @@ public class HttpSemanticsTest extends TestCase {
         result.setStatusCode(400);
         result.addHeader("!Transfer-Encoding", null);
         result.addHeader("Content-Length", "0");
+        result.setStatusMessage("Bad request");
+        doTest(request, result);
+    }
+
+    /**
+     * The bad request has to be answered even when the request line carried a protocol token this implementation does
+     * not recognize. Such a request never reaches prepareRequest(), which is where an unrecognized token is otherwise
+     * turned into a 505, so the token is still in the packet when the error response gets encoded.
+     */
+    public void testHttpHeadersLimitWithUnrecognizedProtocol() throws Throwable {
+        // chunked(false) is left out on purpose - the builder resolves the protocol to apply it, which an
+        // unrecognized token cannot survive on the client side either
+        final Builder builder = HttpRequestPacket.builder().method("GET").uri("/path").header("Host", "localhost:" + PORT).protocol("HTTP/1.2")
+                .maxNumHeaders(-1);
+
+        int i = 1;
+        int headerSize = MAX_HEADERS_SIZE;
+        while (headerSize >= 0) {
+            final String name = "Header-" + i;
+            final String value = "Value-" + i;
+
+            builder.header(name, value);
+            i++;
+            headerSize -= name.length() + value.length();
+        }
+
+        final HttpRequestPacket request = builder.build();
+
+        ExpectedResult result = new ExpectedResult();
+        result.setProtocol("HTTP/1.1");
+        result.setStatusCode(400);
         result.setStatusMessage("Bad request");
         doTest(request, result);
     }


### PR DESCRIPTION
- Fixes #2301

## Problem

When the request line leaves a non-empty protocol token this implementation does not recognise, and the header block
then fails to parse, `onHttpHeaderError()` cannot serialize the 400 it is trying to send. The token is still in the
packet, `prepareResponse()` reads it back through `request.getProtocol()`, and `Protocol.valueOf(DataChunk)` throws
`IllegalStateException: Unknown protocol <token>`.

The throw escapes `commitAndCloseAsError()` before `ctx.write(resBuf)`, so:

- the client receives nothing - a bare connection close instead of the 400 the server decided to send;
- `DefaultFilterChain` logs `GRIZZLY0013` at WARNING with a full stack trace, once per request, for what is purely a
  client error.

Any client that can open a TCP connection to an HTTP listener triggers it unauthenticated, with 28 bytes:

```
printf 'GET /x JUNK/9.9\r\n\xc0Bad: v\r\n\r\n' | nc localhost 8080
```

`prepareRequest()` already handles an unrecognised token - it catches the `IllegalStateException`, answers 505, and
repairs the packet with `setProtocol(Protocol.HTTP_1_1)`. That repair is reached only from `onHttpHeaderParsed()`,
i.e. after the entire header block has parsed, so any header-parse failure bypasses it and the error path fails on
exactly the input it exists to reject.

An empty protocol token is unaffected: `Protocol.valueOf()` maps zero length to `HTTP_0_9`. The token has to be
non-empty and unrecognised; one character is enough.

Reached by accident as well as by a crafted request: of 200 random 300-byte binary blobs sent to a listener, 36 (18%)
produced the WARNING. A TLS `ClientHello` arriving on a plaintext listener - a browser opening `https://` against a
listener that is not secured - is this shape of input. #1980 is the same stack, reported in 2017 against 2.3.25.

## Change

`sendBadRequestResponse()` normalises the request protocol before the error response is encoded, applying the same
HTTP/1.1 assumption `prepareRequest()` already makes for its 505. It is the single point both `onHttpHeaderError()`
and `onHttpContentError()` pass through, so one call covers both.

Nothing on the normal path changes: by the time a response is prepared for a request that parsed, the protocol is
either recognised or has already been replaced by `prepareRequest()`.

## Tests

`HttpSemanticsTest.testHttpHeadersLimitWithUnrecognizedProtocol` - `testHttpHeadersLimit` with `HTTP/1.2` in the
request line instead of `HTTP/1.1`, asserting the same `HTTP/1.1 400` the recognised-protocol case already asserts.
Without the change it errors: the server logs `IllegalStateException: Unknown protocol HTTP/1.2` and the client
connection closes with no response at all.

`chunked(false)` is left out of the new test on purpose - `HttpHeader.Builder.build()` resolves the protocol to apply
it, so an unrecognised token cannot survive the client-side builder either.

`mvn -pl modules/http -am test`: 383 + 303 tests, no failures.
`mvn -pl modules/http-server -am test`: 319 tests, no failures.

Verified against a running GlassFish 8.0.3 (Grizzly 5.0.2) before the change: the 28-byte request above returns zero
bytes and appends the `GRIZZLY0013` WARNING with its stack trace to `server.log`.
