### PR TITLE
Initialize internal variables when recycling objects

### DIFF
--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeaderBlockFragment.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeaderBlockFragment.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -72,6 +73,7 @@ public abstract class HeaderBlockFragment extends Http2Frame {
             return;
         }
 
+        truncated = false;
         compressedHeaders = null;
         super.recycle();
     }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeaderBlockHead.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeaderBlockHead.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -55,6 +56,7 @@ public abstract class HeaderBlockHead extends HeaderBlockFragment {
             return;
         }
 
+        padLength = 0;
         super.recycle();
     }
 

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeadersFrame.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/HeadersFrame.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -143,9 +144,10 @@ public class HeadersFrame extends HeaderBlockHead {
             return;
         }
 
-        padLength = 0;
+        exclusive = false;
         streamDependency = 0;
         weight = 0;
+        compressedHeadersLen = 0;
 
         super.recycle();
         ThreadCache.putToCache(CACHE_IDX, this);

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/PriorityFrame.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/PriorityFrame.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -127,6 +128,7 @@ public class PriorityFrame extends Http2Frame {
             return;
         }
 
+        isExclusive = false;
         streamDependency = 0;
         weight = 0;
 

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/PushPromiseFrame.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/frames/PushPromiseFrame.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -96,7 +97,6 @@ public class PushPromiseFrame extends HeaderBlockHead {
             return;
         }
 
-        padLength = 0;
         promisedStreamId = 0;
 
         super.recycle();


### PR DESCRIPTION
+ When recycling, uninitialized variables may lead to unintended behavior in HTTP/2.
+ This issue is related to `work_items/219` on https://gitlab.eclipse.org, which was reported privately ("Repeated HTTP/2 requests result in frequent HTTP 431 errors and...").
