### PR TITLE
Workaround for off-by-one error in HTTP/2 max concurrent streams checks

### DIFF
--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -941,7 +941,7 @@ public class Http2Session {
                 return null; // if the session is closed is set - return null to ignore stream creation
             }
 
-            if (concurrentStreamsCount.get() >= getLocalMaxConcurrentStreams()) {
+            if (concurrentStreamsCount.get() > getLocalMaxConcurrentStreams()) {
                 // throw Session level exception because headers were not decompressed,
                 // so compression context is lost
                 throw new Http2SessionException(ErrorCode.REFUSED_STREAM);
@@ -990,7 +990,7 @@ public class Http2Session {
                 throw new Http2StreamException(streamId, ErrorCode.REFUSED_STREAM, "Session is closed");
             }
 
-            if (concurrentStreamsCount.get() >= getLocalMaxConcurrentStreams()) {
+            if (concurrentStreamsCount.get() > getLocalMaxConcurrentStreams()) {
                 throw new Http2StreamException(streamId, ErrorCode.REFUSED_STREAM);
             }
 


### PR DESCRIPTION
This PR proposes an *acceptable workaround* for the issue reported and described in #2304 to mitigate the effect unless a solution is found for the *root* cause.